### PR TITLE
Create User Databases

### DIFF
--- a/apps/api/src/clients/meilisearch.ts
+++ b/apps/api/src/clients/meilisearch.ts
@@ -27,7 +27,7 @@ export const createUserIndex = async (indexName: string) => {
   const userIndex = meilisearchClient.index(indexName);
 
   logger.info(
-    { indexName, category: LogCategory.DATABASE, event: "index_created" },
+    { indexName, category: LogCategory.DATABASE, event: "index_created.start" },
     "Creating user index...",
   );
 
@@ -50,7 +50,12 @@ export const createUserIndex = async (indexName: string) => {
   const task = await meilisearchClient.waitForTask(updateTaskUid);
 
   logger.info(
-    { task, indexName, category: LogCategory.DATABASE, event: "index_created" },
+    {
+      task,
+      indexName,
+      category: LogCategory.DATABASE,
+      event: "index_created.end",
+    },
     "Created user index.",
   );
 };

--- a/apps/api/src/clients/turso.ts
+++ b/apps/api/src/clients/turso.ts
@@ -1,8 +1,186 @@
-import { createClient } from "@tursodatabase/api";
+import { createClient as createPlatformClient } from "@tursodatabase/api";
 import { config } from "../config";
+import { createClient as createDbClient } from "@libsql/client";
+import { customAlphabet } from "nanoid";
+import { db as centralDb } from "../db";
+import { migrations } from "../db/schema/migrations";
+import { LogCategory, logger } from "../logger";
+import { gt, asc } from "drizzle-orm";
 
-export const tursoClient = createClient({
+export const tursoPlatformClient = createPlatformClient({
   org: config.TURSO_ORG_SLUG,
   token: config.TURSO_PLATFORM_API_KEY,
 });
 
+/**
+ * Creates a new database for a user in Turso.
+ * The format of the database name is `user-{userId}`.
+ *
+ * @returns The name of the new database and token.
+ */
+export const createNewUserDb = async () => {
+  /**
+   * The alphabet containing only the characters that can be used
+   * to name a database in Turso.
+   */
+  const customTursoDbNameAlphabet = "abcdefghijklmnopqrstuvwxyz-1234567890";
+
+  const randomId = customAlphabet(customTursoDbNameAlphabet, 21)();
+  const dbName = `user-${randomId}`;
+
+  logger.info(
+    { dbName, category: LogCategory.DATABASE, event: "user_db_create.start" },
+    "Creating user database in Turso...",
+  );
+
+  const newDb = await tursoPlatformClient.databases.create(dbName, {
+    group: config.TURSO_DB_GROUP,
+  });
+
+  logger.info(
+    { dbName, category: LogCategory.DATABASE, event: "user_db_create.end" },
+    "Created user database in Turso.",
+  );
+
+  logger.info(
+    {
+      dbName,
+      category: LogCategory.DATABASE,
+      event: "user_db_token_create.start",
+    },
+    "Creating user database token in Turso...",
+  );
+
+  const accessToken = await tursoPlatformClient.databases.createToken(
+    newDb.name,
+    {
+      authorization: "full-access",
+      expiration: "2w",
+    },
+  );
+
+  logger.info(
+    {
+      dbName,
+      category: LogCategory.DATABASE,
+      event: "user_db_token_create.end",
+    },
+    "Created user database token in Turso.",
+  );
+
+  return { newDb, accessToken };
+};
+
+/**
+ * Applies all migrations in the registry to a given database
+ * that haven't already been applied.
+ *
+ * This is typically done for a new user database on creation
+ * to bring the database up to date with the latest migrations.
+ */
+export const applyAllNewMigrations = async ({
+  dbName,
+  token,
+  dbUrl,
+}: {
+  dbUrl: string;
+  token: string;
+  dbName: string;
+}) => {
+  const userDbClient = createDbClient({ url: dbUrl, authToken: token });
+
+  const lastAppliedVersion = await (async () => {
+    try {
+      const { rows } = await userDbClient.execute(
+        "SELECT version FROM migrations WHERE status = 'applied' ORDER BY version DESC LIMIT 1",
+      );
+
+      // Versioning starts at 1 in the schema registry
+      // so 0 means we apply all migrations.
+      return (rows[0]?.version ?? 0) as number;
+    } catch (err) {
+      // If migrations table doesn't exist,
+      // it means this is a fresh database
+      // and it will throw an error with
+      // the query above.
+      return 0;
+    }
+  })();
+
+  const pendingMigrations = await centralDb
+    .select()
+    .from(migrations)
+    .where(gt(migrations.version, lastAppliedVersion))
+    .orderBy(asc(migrations.version));
+
+  logger.info(
+    {
+      dbName,
+      lastAppliedVersion,
+      category: LogCategory.DATABASE,
+      event: "user_db_migrations_apply.start",
+    },
+    "Applying migrations to user database...",
+  );
+
+  for (const migration of pendingMigrations) {
+    const nowTimestampMs = Date.now();
+
+    // A migration can contain multiple SQL statements
+    const sqlStatements = migration.sql_script
+      .split(";")
+      .map((stmt) => stmt.trim())
+      .filter(Boolean);
+
+    try {
+      await userDbClient.batch(
+        [
+          ...sqlStatements,
+          {
+            sql: "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)",
+            args: [
+              migration.version,
+              migration.description,
+              nowTimestampMs,
+              "applied",
+            ],
+          },
+        ],
+        "write",
+      );
+    } catch (err) {
+      logger.error(
+        {
+          event: "unexpected_error",
+          category: LogCategory.APPLICATION,
+          err,
+          migration,
+          dbUrl,
+        },
+        "Error applying migration to user database. Skipping remaining migrations.",
+      );
+
+      await userDbClient.execute({
+        sql: "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)",
+        args: [
+          migration.version,
+          migration.description,
+          nowTimestampMs,
+          "failed",
+        ],
+      });
+
+      break;
+    }
+  }
+
+  logger.info(
+    {
+      dbName,
+      lastAppliedVersion,
+      category: LogCategory.DATABASE,
+      event: "user_db_migrations_apply.end",
+    },
+    "Applied migrations to user database.",
+  );
+};

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,8 @@ import { toNodeHandler } from "better-auth/node";
 import { config } from "./config";
 import { logger, requestLogger } from "./logger";
 import { traceContextMiddleware } from "./middleware";
+import { migrationsRouter } from "./routers/migrations";
+import { databasesRouter } from "./routers/databases";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -37,6 +39,8 @@ const appRouter = router({
   tags: tagsRouter,
   settings: settingsRouter,
   decks: decksRouter,
+  migrations: migrationsRouter,
+  databasesRouter: databasesRouter,
 });
 
 const app = express();

--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -28,11 +28,6 @@ export const enum LogCategory {
   AUTH = "auth",
   DATABASE = "database",
   APPLICATION = "application",
-  FLASHCARD = "flashcard",
-  DICTIONARY = "dictionary",
-  DECK = "deck",
-  SETTINGS = "settings",
-  TAGS = "tags",
 }
 
 export const logger = pino({

--- a/apps/api/src/routers/databases.ts
+++ b/apps/api/src/routers/databases.ts
@@ -2,7 +2,7 @@ import { router, protectedProcedure } from "../trpc";
 import { db } from "../db";
 import { eq } from "drizzle-orm";
 import { databases, SelectDatabasesSchema } from "../db/schema/databases";
-import { tursoClient } from "../clients/turso";
+import { tursoPlatformClient } from "../clients/turso";
 import { isJwtExpired } from "../utils";
 import { TRPCError } from "@trpc/server";
 
@@ -59,7 +59,7 @@ export const databasesRouter = router({
       const userDb = results[0];
 
       if (userDb?.access_token && isJwtExpired(userDb.access_token)) {
-        const newToken = await tursoClient.databases.createToken(
+        const newToken = await tursoPlatformClient.databases.createToken(
           userDb.db_name,
         );
 

--- a/apps/web/src/components/features/settings/AdminSettingsCardSection.tsx
+++ b/apps/web/src/components/features/settings/AdminSettingsCardSection.tsx
@@ -1,0 +1,143 @@
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { useToast } from "@/hooks/useToast";
+import { trpc } from "@/lib/trpc";
+import { z } from "@/lib/zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useLingui } from "@lingui/react/macro";
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { Textarea } from "@/components/ui/textarea";
+
+const FormSchema = z.object({
+  sqlScript: z.string(),
+  description: z.string(),
+});
+
+export const AdminSettingsCardSection = () => {
+  const { t } = useLingui();
+  const { mutate, error, isError } =
+    trpc.migrations.registerSchema.useMutation();
+  const { toast } = useToast();
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      sqlScript: "",
+      description: "",
+    },
+  });
+
+  const onSubmit = useCallback(async (data: z.infer<typeof FormSchema>) => {
+    mutate(data);
+
+    if (isError) {
+      if (error.message === "UNAUTHORIZED") {
+        toast({
+          title: t`Failed to upload migration`,
+          description: t`You do not have access to upload schema migrations.`,
+        });
+      } else {
+        toast({
+          title: t`Failed to upload migration`,
+          description: t`There was an error uploading your SQL migration`,
+        });
+      }
+    } else {
+      toast({
+        title: t`Migration successfully registered.`,
+      });
+    }
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Trans>Schema Migrations</Trans>
+        </CardTitle>
+
+        <CardDescription>
+          <Trans>Add a new SQL migration.</Trans>
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="flex flex-col gap-y-4 mb-4">
+              <FormField
+                control={form.control}
+                name="sqlScript"
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <FormItem className="space-y-3">
+                    <FormLabel>
+                      <Trans>SQL Script</Trans>*
+                    </FormLabel>
+
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Enter your SQL migration script here"
+                        className="w-full"
+                      />
+                    </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem className="space-y-3">
+                    <FormLabel>
+                      <Trans>Description</Trans>
+                    </FormLabel>
+
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Enter a description for your migration"
+                        className="w-full"
+                      />
+                    </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                type="submit"
+                className="w-max"
+                disabled={
+                  !form.formState.isDirty || form.formState.isSubmitting
+                }
+              >
+                <Trans>Save</Trans>
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,14 +1,19 @@
 import {
   inferAdditionalFields,
   emailOTPClient,
+  adminClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
-import type { auth } from "../../../api/src/auth";
 import { TRACE_ID_HEADER, generateTraceId } from "./utils";
+import type { auth } from "../../../api/src/auth";
 
 export const authClient = createAuthClient({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  plugins: [inferAdditionalFields<typeof auth>(), emailOTPClient()],
+  plugins: [
+    inferAdditionalFields<typeof auth>(),
+    emailOTPClient(),
+    adminClient(),
+  ],
   fetchOptions: {
     headers: {
       [TRACE_ID_HEADER]: generateTraceId(),

--- a/apps/web/src/routes/_app-layout/settings/route.lazy.tsx
+++ b/apps/web/src/routes/_app-layout/settings/route.lazy.tsx
@@ -30,6 +30,8 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import { ImportResponseError } from "@/lib/error";
 import { useCallback, useState } from "react";
 import { useInstantSearch } from "react-instantsearch";
+import { authClient } from "@/lib/auth-client";
+import { AdminSettingsCardSection } from "@/components/features/settings/AdminSettingsCardSection";
 
 const Settings = () => {
   const { t } = useLingui();
@@ -37,6 +39,7 @@ const Settings = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
   const { refresh } = useInstantSearch();
+  const { data: userData } = authClient.useSession();
 
   const exportDictionary = useCallback(async (includeFlashcards = false) => {
     try {
@@ -371,6 +374,8 @@ const Settings = () => {
       </Card>
 
       <FlashcardSettingsCardSection />
+
+      {userData?.user.role === "admin" && <AdminSettingsCardSection />}
     </Page>
   );
 };


### PR DESCRIPTION
This PR creates user dbs on user creation and applies all migrations in the schema registry to them automatically. It also stores the connection information associated to the respective user's id in the central db. Also, I added frontend inputs that allow adding sql migrations to the schema registry only for admins