### PR TITLE
docs: switch cloudflared tunnel to remote/token-based setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ local-db:
 
 # Cloudflared tunnel for local dev — exposes local API over HTTPS
 # so the mobile dev client and OAuth callbacks (Apple Sign In) can reach it.
-# Requires `cloudflared login` once to fetch credentials for the bahar-dev tunnel.
+# bahar-dev is a remotely-managed (dashboard) tunnel; cloudflared reads its
+# token from the TUNNEL_TOKEN env var. Set it before running, e.g.:
+#   export TUNNEL_TOKEN=$(op read 'op://Bahar/Cloudflared tunnel token/password')
 tunnel:
-	cloudflared tunnel run bahar-dev
+	cloudflared tunnel run
 
 # Serve production web app
 serve:

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -78,9 +78,14 @@ The API runs on `http://localhost:3000`.
 
 4. For testing Polar payments or SSO providers (GitHub, Apple Sign in) locally, use a Cloudflare Tunnel to expose the API. SSO providers reject `http://localhost` callbacks over unencrypted HTTP, so the tunnel is required to test any OAuth flow.
 
-See [the docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/create-local-tunnel/) to set up Cloudflare Tunnel. Contact an admin to get the tunnel name and config file. You'll need access to Cloudflare.
+The `bahar-dev` tunnel is a [remotely-managed (dashboard) tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/) — its routing (public hostname → `http://localhost:3000`) lives in the Cloudflare Zero Trust dashboard, and its token is stored in Cloudflare (re-fetch anytime with `cloudflared tunnel token bahar-dev`). You'll need access to the Cloudflare account; the token is kept in 1Password (`op://Bahar/Cloudflared tunnel token/password`).
 
-Once set up, run the tunnel with `cloudflared tunnel run <tunnel-name>`.
+`cloudflared` reads the token from the `TUNNEL_TOKEN` env var, so set it and run the tunnel:
+
+```bash
+export TUNNEL_TOKEN=$(op read 'op://Bahar/Cloudflared tunnel token/password')
+cloudflared tunnel run
+```
 
 When running with the tunnel, update these env vars to point at the tunnel domain (e.g., `https://local.bahar.dev`):
 


### PR DESCRIPTION
bahar-dev is now a remotely-managed (dashboard) tunnel. Update the Makefile target to run via the TUNNEL_TOKEN env var and document fetching the token from 1Password, replacing the old name-based `cloudflared tunnel run bahar-dev` + local credentials flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development Cloudflare Tunnel setup documentation with streamlined token-based configuration approach and detailed setup steps

* **Chores**
  * Refined tunnel configuration mechanism to use environment variable-based selection for improved local development experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->