### PR TITLE
feat: add bahar CLI for direct dictionary/flashcard data access

### DIFF
--- a/.claude/skills/bahar-data-access/SKILL.md
+++ b/.claude/skills/bahar-data-access/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: bahar-data-access
+description: >
+  Explains how an agent can access a Bahar user's own dictionary and flashcard data:
+  it lives in a personal Turso SQLite database (not behind a REST API), the `bahar`
+  CLI handles login and hands back direct connection credentials, and the agent then
+  queries that database directly with any SQL/libsql client. Use when a user asks to
+  look up, search, review, or analyze their own dictionary entries, flashcards, decks,
+  or study stats via chat — e.g. "what words am I struggling with", "add this word to
+  my dictionary", "quiz me on my hardest cards", "how many words have I added this
+  month".
+---
+
+# Bahar data access (for agents)
+
+## Where the data lives
+
+Each Bahar user has their own personal SQLite database, hosted on Turso, separate from
+the app's central database (auth, billing, etc.). There is no REST API for dictionary or
+flashcard data — the web and mobile apps connect to this per-user database directly, and
+so should you.
+
+## Step 1 — log in (once per machine)
+
+```bash
+bahar login
+```
+
+Opens the user's browser to sign in to their Bahar account, then stores a personal API
+key locally (`~/.config/bahar/credentials.json`, or the platform equivalent). Only needs
+to be run again if the user explicitly logs out or the key is revoked.
+
+## Step 2 — get connection info
+
+```bash
+bahar db-info
+```
+
+Prints JSON with everything needed to connect: `hostname`, `db_name`, and a short-lived
+`access_token` (refreshed automatically by the CLI's backend when it's close to
+expiring, so always call this fresh rather than caching the token yourself).
+
+## Step 3 — connect directly
+
+Use any libsql-compatible client with the `hostname` and `access_token` from step 2,
+e.g. in Node/Bun:
+
+```ts
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: `libsql://${hostname}`,
+  authToken: access_token,
+});
+
+const result = await client.execute("SELECT word, translation FROM dictionary_entries LIMIT 5");
+```
+
+Any language with a libsql/sqlite client works the same way — this isn't Node-specific.
+
+## Step 4 — discover the schema live, don't assume it
+
+Don't hardcode column names from this file into your queries. The schema evolves over
+time (Bahar runs real migrations against it), so the only reliable source of truth is
+the database itself:
+
+```sql
+SELECT name, sql FROM sqlite_master WHERE type = 'table';
+```
+
+Run this once at the start of a session to see the exact current columns before writing
+queries, rather than guessing.
+
+## Orientation — tables you'll typically care about
+
+These names are stable; treat their *columns* as unknown until you've introspected them
+per Step 4.
+
+- `dictionary_entries` — the user's personal Arabic dictionary (word, translation,
+  definition, morphology, tags, examples, etc.)
+- `flashcards` — one row per study direction (forward/reverse) per dictionary entry,
+  holding FSRS (spaced-repetition) scheduling state
+- `decks` — user-defined groupings of flashcards
+- `user_stats` — aggregate study stats
+- `settings` — per-user app settings
+- `migrations` — internal schema-version bookkeeping; not user data, ignore it
+
+## Gotchas
+
+- Several `dictionary_entries` columns (`root`, `tags`, `antonyms`, `examples`,
+  `morphology`) are stored as JSON *text*. The web/mobile apps parse them through
+  Drizzle's `mode: "json"` on the way out — a raw SQL client will hand you back the raw
+  JSON string, so `JSON.parse()` (or your language's equivalent) it yourself.
+- `flashcards` scheduling fields (`difficulty`, `stability`, `due`, `state`, `reps`,
+  `lapses`, etc.) are FSRS algorithm state, not plain data. Reading them for
+  study-coaching purposes is safe; writing to them to record a review requires running
+  the actual FSRS update logic first (see `packages/fsrs` in this repo) — don't
+  hand-write a new `due`/`state` value directly, it will desync the schedule.
+  Straightforward additive writes (new dictionary entries, new flashcards/decks) don't
+  have this concern.
+- The `access_token` from `bahar db-info` is a real credential scoped to that user's
+  database. Treat it like a password — don't print it to logs or persist it anywhere
+  beyond what's needed to make the connection.

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,88 @@
+name: Release CLI
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "cli-v*"
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release URLs are configured
+        run: |
+          if [ -z "${{ vars.BAHAR_WEB_URL }}" ] || [ -z "${{ vars.BAHAR_API_URL }}" ]; then
+            echo "::error::Set the BAHAR_WEB_URL and BAHAR_API_URL repository variables (Settings > Secrets and variables > Actions > Variables) before cutting a CLI release."
+            exit 1
+          fi
+
+      - name: Build binaries
+        working-directory: apps/cli
+        run: |
+          declare -A targets=(
+            [bun-linux-x64]=bahar-linux-x64
+            [bun-darwin-x64]=bahar-darwin-x64
+            [bun-darwin-arm64]=bahar-darwin-arm64
+            [bun-windows-x64]=bahar-windows-x64.exe
+          )
+
+          for target in "${!targets[@]}"; do
+            asset="${targets[$target]}"
+
+            bun build --compile \
+              --target="$target" \
+              --minify-whitespace \
+              --minify-syntax \
+              --define "process.env.BAHAR_WEB_URL='${{ vars.BAHAR_WEB_URL }}'" \
+              --define "process.env.BAHAR_API_URL='${{ vars.BAHAR_API_URL }}'" \
+              --outfile "$asset" \
+              src/index.ts
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: |
+            apps/cli/bahar-linux-x64
+            apps/cli/bahar-darwin-x64
+            apps/cli/bahar-darwin-arm64
+            apps/cli/bahar-windows-x64.exe
+
+  release:
+    name: Create GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: dist
+
+      - name: Create release and upload binaries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            dist/bahar-linux-x64 \
+            dist/bahar-darwin-x64 \
+            dist/bahar-darwin-arm64 \
+            dist/bahar-windows-x64.exe \
+            --repo "${{ github.repository }}" \
+            --title "Bahar CLI ${{ github.ref_name }}" \
+            --generate-notes

--- a/apps/api/drizzle/0021_chunky_mister_fear.sql
+++ b/apps/api/drizzle/0021_chunky_mister_fear.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `apikeys` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`start` text,
+	`prefix` text,
+	`key` text NOT NULL,
+	`user_id` text NOT NULL,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT true,
+	`rate_limit_enabled` integer DEFAULT true,
+	`rate_limit_time_window` integer DEFAULT 86400000,
+	`rate_limit_max` integer DEFAULT 10,
+	`request_count` integer DEFAULT 0,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`permissions` text,
+	`metadata` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `apikeys_key_idx` ON `apikeys` (`key`);--> statement-breakpoint
+CREATE INDEX `apikeys_userId_idx` ON `apikeys` (`user_id`);

--- a/apps/api/drizzle/meta/0021_snapshot.json
+++ b/apps/api/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,963 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "740ff79d-91ac-4f30-86c5-1f67bdca2bc3",
+  "prevId": "d0a6d197-9ea5-4eca-a302-ca4e2cecb851",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikeys": {
+      "name": "apikeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikeys_key_idx": {
+          "name": "apikeys_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "apikeys_userId_idx": {
+          "name": "apikeys_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikeys_user_id_users_id_fk": {
+          "name": "apikeys_user_id_users_id_fk",
+          "tableFrom": "apikeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consent_events": {
+      "name": "consent_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "consentEvents_userId_idx": {
+          "name": "consentEvents_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "consent_events_user_id_users_id_fk": {
+          "name": "consent_events_user_id_users_id_fk",
+          "tableFrom": "consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscriptionStatus": {
+          "name": "subscriptionStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "databases": {
+      "name": "databases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "db_name": {
+          "name": "db_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "databases_user_id_unique": {
+          "name": "databases_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "databases_user_id_users_id_fk": {
+          "name": "databases_user_id_users_id_fk",
+          "tableFrom": "databases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migrations": {
+      "name": "migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sql_script": {
+          "name": "sql_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "revlogs": {
+      "name": "revlogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dictionary_entry_id": {
+          "name": "dictionary_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_timestamp_ms": {
+          "name": "due_timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_timestamp_ms": {
+          "name": "review_timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'forward'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'review'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "revlogs_entry_history_idx": {
+          "name": "revlogs_entry_history_idx",
+          "columns": [
+            "user_id",
+            "dictionary_entry_id",
+            "source",
+            "review_timestamp_ms"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "revlogs_user_id_users_id_fk": {
+          "name": "revlogs_user_id_users_id_fk",
+          "tableFrom": "revlogs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1775969867626,
       "tag": "0020_harsh_celestials",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1783035007051,
+      "tag": "0021_chunky_mister_fear",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -14,6 +14,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import {
   admin,
   anonymous,
+  apiKey,
   createAuthMiddleware,
   emailOTP,
   openAPI,
@@ -30,7 +31,13 @@ import {
   tursoPlatformClient,
 } from "./clients/turso";
 import { db } from "./db";
-import { accounts, sessions, users, verifications } from "./db/schema/auth";
+import {
+  accounts,
+  apikeys,
+  sessions,
+  users,
+  verifications,
+} from "./db/schema/auth";
 import { databases } from "./db/schema/databases";
 import { revlogs } from "./db/schema/revlogs";
 import { getAllowedDomains } from "./utils";
@@ -46,6 +53,7 @@ const OTP_LENGTH = 6;
 const OTP_EXPIRY_SECS = 60 * 5; // 5 minutes
 const SESSION_COOKIE_CACHE_EXPIRY_SECS = 60 * 5; // 5 minutes
 const MOBILE_DEEP_LINK_SCHEME = "bahar://";
+const CLI_API_KEY_PREFIX = "bahar_cli_";
 
 const allowedDomains = getAllowedDomains([config.WEB_CLIENT_DOMAIN]);
 
@@ -446,6 +454,10 @@ export const auth = betterAuth({
     openAPI(),
     expo(),
     admin(),
+    apiKey({
+      defaultPrefix: CLI_API_KEY_PREFIX,
+      enableSessionForAPIKeys: true,
+    }),
     consentEventsPlugin(),
     anonymous({
       onLinkAccount: async ({ anonymousUser, newUser }) => {
@@ -692,6 +704,7 @@ export const auth = betterAuth({
       users,
       sessions,
       accounts,
+      apikeys,
     },
   }),
   databaseHooks: {

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -54,6 +54,7 @@ const OTP_EXPIRY_SECS = 60 * 5; // 5 minutes
 const SESSION_COOKIE_CACHE_EXPIRY_SECS = 60 * 5; // 5 minutes
 const MOBILE_DEEP_LINK_SCHEME = "bahar://";
 const CLI_API_KEY_PREFIX = "bahar_cli_";
+const CLI_API_KEY_EXPIRY_SECS = 60 * 60 * 24 * 7; // 7 days
 
 const allowedDomains = getAllowedDomains([config.WEB_CLIENT_DOMAIN]);
 
@@ -457,6 +458,9 @@ export const auth = betterAuth({
     apiKey({
       defaultPrefix: CLI_API_KEY_PREFIX,
       enableSessionForAPIKeys: true,
+      keyExpiration: {
+        defaultExpiresIn: CLI_API_KEY_EXPIRY_SECS,
+      },
     }),
     consentEventsPlugin(),
     anonymous({

--- a/apps/api/src/db/schema/auth.ts
+++ b/apps/api/src/db/schema/auth.ts
@@ -105,6 +105,41 @@ export const verifications = sqliteTable(
   (table) => [index("verifications_identifier_idx").on(table.identifier)]
 );
 
+export const apikeys = sqliteTable(
+  "apikeys",
+  {
+    id: text("id").primaryKey(),
+    name: text("name"),
+    start: text("start"),
+    prefix: text("prefix"),
+    key: text("key").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    refillInterval: integer("refill_interval"),
+    refillAmount: integer("refill_amount"),
+    lastRefillAt: integer("last_refill_at", { mode: "timestamp_ms" }),
+    enabled: integer("enabled", { mode: "boolean" }).default(true),
+    rateLimitEnabled: integer("rate_limit_enabled", {
+      mode: "boolean",
+    }).default(true),
+    rateLimitTimeWindow: integer("rate_limit_time_window").default(86_400_000),
+    rateLimitMax: integer("rate_limit_max").default(10),
+    requestCount: integer("request_count").default(0),
+    remaining: integer("remaining"),
+    lastRequest: integer("last_request", { mode: "timestamp_ms" }),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+    permissions: text("permissions"),
+    metadata: text("metadata"),
+  },
+  (table) => [
+    index("apikeys_key_idx").on(table.key),
+    index("apikeys_userId_idx").on(table.userId),
+  ]
+);
+
 export const consentEvents = sqliteTable(
   "consent_events",
   {
@@ -127,6 +162,7 @@ export const consentEvents = sqliteTable(
 export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   accounts: many(accounts),
+  apikeys: many(apikeys),
   consentEvents: many(consentEvents),
 }));
 
@@ -140,6 +176,13 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
 export const accountsRelations = relations(accounts, ({ one }) => ({
   users: one(users, {
     fields: [accounts.userId],
+    references: [users.id],
+  }),
+}));
+
+export const apikeysRelations = relations(apikeys, ({ one }) => ({
+  users: one(users, {
+    fields: [apikeys.userId],
     references: [users.id],
   }),
 }));

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bahar/cli",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "bahar": "./src/index.ts"
+  },
+  "scripts": {
+    "clean": "rm -rf ./dist",
+    "typecheck": "tsc --noEmit",
+    "prebuild": "npm run clean && npm run typecheck",
+    "build:binary": "bun build --compile --minify-whitespace --minify-syntax --outfile bahar src/index.ts",
+    "dev": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "@bunli/core": "0.1.0",
+    "open": "^10.1.0"
+  },
+  "devDependencies": {
+    "@bahar/typescript-config": "workspace:*",
+    "bun-types": "^1.3.5",
+    "typescript": "^5.8.3"
+  }
+}

--- a/apps/cli/scripts/install.ps1
+++ b/apps/cli/scripts/install.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "Shunseii/bahar"
+$BinName = "bahar.exe"
+$InstallDir = Join-Path $env:LOCALAPPDATA "Bahar\bin"
+
+Write-Host "Fetching latest Bahar CLI release..."
+
+$releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases"
+$release = $releases | Where-Object { $_.tag_name -like "cli-v*" -and -not $_.draft } | Select-Object -First 1
+
+if (-not $release) {
+    Write-Error "Could not find a CLI release. Please try again later."
+    exit 1
+}
+
+$asset = "bahar-windows-x64.exe"
+$url = "https://github.com/$Repo/releases/download/$($release.tag_name)/$asset"
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Write-Host "Downloading $asset ($($release.tag_name))..."
+Invoke-WebRequest -Uri $url -OutFile (Join-Path $InstallDir $BinName)
+
+$currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($currentPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$currentPath;$InstallDir", "User")
+    Write-Host "Added $InstallDir to your PATH. Restart your terminal for this to take effect."
+}
+
+Write-Host "Installed to $InstallDir\$BinName"
+Write-Host "Run 'bahar login' to get started."

--- a/apps/cli/scripts/install.sh
+++ b/apps/cli/scripts/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="Shunseii/bahar"
+BIN_NAME="bahar"
+
+detect_asset() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux) echo "bahar-linux-x64" ;;
+    Darwin)
+      case "$arch" in
+        arm64) echo "bahar-darwin-arm64" ;;
+        *) echo "bahar-darwin-x64" ;;
+      esac
+      ;;
+    *)
+      echo "Unsupported OS: $os" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_install_dir() {
+  if [ -n "${XDG_BIN_HOME:-}" ]; then
+    echo "$XDG_BIN_HOME"
+  else
+    echo "$HOME/.local/bin"
+  fi
+}
+
+add_to_path() {
+  install_dir="$1"
+  shell_name="$(basename "${SHELL:-bash}")"
+
+  case "$shell_name" in
+    fish)
+      profile="$HOME/.config/fish/config.fish"
+      line="fish_add_path $install_dir"
+      ;;
+    zsh)
+      profile="$HOME/.zshrc"
+      line="export PATH=\"$install_dir:\$PATH\""
+      ;;
+    *)
+      profile="$HOME/.bashrc"
+      line="export PATH=\"$install_dir:\$PATH\""
+      ;;
+  esac
+
+  mkdir -p "$(dirname "$profile")"
+
+  if [ -f "$profile" ] && grep -qF "$install_dir" "$profile"; then
+    return
+  fi
+
+  {
+    echo ""
+    echo "# Added by the Bahar CLI installer"
+    echo "$line"
+  } >> "$profile"
+
+  echo "Added $install_dir to PATH in $profile. Restart your shell or run: source $profile"
+}
+
+main() {
+  asset="$(detect_asset)"
+  install_dir="$(detect_install_dir)"
+
+  echo "Fetching latest Bahar CLI release..."
+
+  tag="$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
+    | grep -m1 -o '"tag_name": *"cli-v[^"]*"' \
+    | sed -E 's/.*"(cli-v[^"]+)".*/\1/')"
+
+  if [ -z "$tag" ]; then
+    echo "Could not find a CLI release. Please try again later." >&2
+    exit 1
+  fi
+
+  url="https://github.com/$REPO/releases/download/$tag/$asset"
+
+  mkdir -p "$install_dir"
+
+  echo "Downloading $asset ($tag)..."
+  curl -fsSL "$url" -o "$install_dir/$BIN_NAME"
+  chmod +x "$install_dir/$BIN_NAME"
+
+  echo "Installed to $install_dir/$BIN_NAME"
+
+  case ":$PATH:" in
+    *":$install_dir:"*) ;;
+    *) add_to_path "$install_dir" ;;
+  esac
+
+  echo "Run 'bahar login' to get started."
+}
+
+main

--- a/apps/cli/src/commands/db-info.ts
+++ b/apps/cli/src/commands/db-info.ts
@@ -1,0 +1,32 @@
+import { defineCommand } from "@bunli/core";
+import { API_URL } from "../lib/config";
+import { loadCredentials } from "../lib/credentials";
+
+export const dbInfoCommand = defineCommand({
+  name: "db-info",
+  description:
+    "Print connection info (hostname, db name, access token) for your personal database",
+  handler: async ({ colors }) => {
+    const credentials = await loadCredentials();
+
+    if (!credentials) {
+      console.error(colors.red("Not logged in. Run `bahar login` first."));
+      process.exitCode = 1;
+      return;
+    }
+
+    const response = await fetch(new URL("/databases/user", API_URL), {
+      headers: { "x-api-key": credentials.token },
+    });
+
+    if (!response.ok) {
+      console.error(
+        colors.red(`Failed to fetch database info (${response.status}).`)
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(JSON.stringify(await response.json(), null, 2));
+  },
+});

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,76 @@
+import { randomBytes } from "node:crypto";
+import { defineCommand } from "@bunli/core";
+import open from "open";
+import { WEB_URL } from "../lib/config";
+import { saveCredentials } from "../lib/credentials";
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+const waitForCallback = (state: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let server: ReturnType<typeof Bun.serve> | undefined;
+
+    const timeout = setTimeout(() => {
+      server?.stop();
+      reject(new Error("Login timed out. Please try again."));
+    }, LOGIN_TIMEOUT_MS);
+
+    server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+
+        if (url.pathname !== "/callback") {
+          return new Response("Not found", { status: 404 });
+        }
+
+        const receivedState = url.searchParams.get("state");
+        const receivedToken = url.searchParams.get("token");
+
+        if (receivedState !== state || !receivedToken) {
+          return new Response("Invalid login callback.", { status: 400 });
+        }
+
+        clearTimeout(timeout);
+        resolve(receivedToken);
+
+        // Stop after the response flushes rather than inside the handler.
+        setTimeout(() => server?.stop(), 0);
+
+        return new Response(
+          "<html><body>You can close this tab and return to your terminal.</body></html>",
+          { headers: { "Content-Type": "text/html" } }
+        );
+      },
+    });
+
+    const authUrl = new URL("/cli-auth", WEB_URL);
+    authUrl.searchParams.set("port", String(server.port));
+    authUrl.searchParams.set("state", state);
+
+    open(authUrl.toString());
+  });
+
+export const loginCommand = defineCommand({
+  name: "login",
+  description: "Log in to your Bahar account",
+  handler: async ({ colors, spinner }) => {
+    const state = randomBytes(16).toString("hex");
+
+    const s = spinner();
+    s.start("Waiting for you to finish signing in in your browser...");
+
+    try {
+      const token = await waitForCallback(state);
+
+      await saveCredentials({ token });
+
+      s.succeed(colors.green("Logged in successfully."));
+    } catch (error) {
+      s.fail(
+        colors.red(error instanceof Error ? error.message : "Login failed.")
+      );
+      process.exitCode = 1;
+    }
+  },
+});

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -1,0 +1,58 @@
+import { rename } from "node:fs/promises";
+import { defineCommand } from "@bunli/core";
+import packageJson from "../../package.json";
+import {
+  getAssetNameForPlatform,
+  getLatestRelease,
+  versionFromTag,
+} from "../lib/update";
+
+export const updateCommand = defineCommand({
+  name: "update",
+  description: "Update the Bahar CLI to the latest version",
+  handler: async ({ colors, spinner }) => {
+    const s = spinner();
+    s.start("Checking for updates...");
+
+    const release = await getLatestRelease();
+
+    if (!release) {
+      s.fail(
+        colors.red("Could not check for updates. Please try again later.")
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const latestVersion = versionFromTag(release.tag_name);
+
+    if (latestVersion === packageJson.version) {
+      s.succeed("Already up to date.");
+      return;
+    }
+
+    const assetName = getAssetNameForPlatform();
+    const asset = release.assets.find((a) => a.name === assetName);
+
+    if (!asset) {
+      s.fail(colors.red(`No release found for your platform (${assetName}).`));
+      process.exitCode = 1;
+      return;
+    }
+
+    s.update(`Downloading ${latestVersion}...`);
+
+    const binaryResponse = await fetch(asset.browser_download_url);
+    const tempPath = `${process.execPath}.download`;
+
+    await Bun.write(tempPath, binaryResponse);
+
+    if (process.platform !== "win32") {
+      await Bun.$`chmod +x ${tempPath}`.quiet();
+    }
+
+    await rename(tempPath, process.execPath);
+
+    s.succeed(colors.green(`Updated to ${latestVersion}.`));
+  },
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+import { createCLI } from "@bunli/core";
+import packageJson from "../package.json";
+import { dbInfoCommand } from "./commands/db-info";
+import { loginCommand } from "./commands/login";
+import { updateCommand } from "./commands/update";
+import { checkForUpdate } from "./lib/update";
+
+const cli = createCLI({
+  name: "bahar",
+  version: packageJson.version,
+  description:
+    "Query your Bahar dictionary and flashcard data from the command line",
+});
+
+cli.command(loginCommand);
+cli.command(dbInfoCommand);
+cli.command(updateCommand);
+
+await checkForUpdate();
+
+await cli.init();
+await cli.run();

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -1,0 +1,4 @@
+export const API_URL = process.env.BAHAR_API_URL ?? "http://localhost:3000";
+export const WEB_URL = process.env.BAHAR_WEB_URL ?? "http://localhost:5173";
+
+export const GITHUB_REPO = "Shunseii/bahar";

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -1,0 +1,49 @@
+import { chmod } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface Credentials {
+  token: string;
+}
+
+export const configDir = (): string => {
+  if (process.platform === "win32") {
+    return join(
+      process.env.APPDATA ?? join(homedir(), "AppData", "Roaming"),
+      "bahar"
+    );
+  }
+
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support", "bahar");
+  }
+
+  return join(
+    process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"),
+    "bahar"
+  );
+};
+
+const credentialsPath = (): string => join(configDir(), "credentials.json");
+
+export const saveCredentials = async (
+  credentials: Credentials
+): Promise<void> => {
+  const path = credentialsPath();
+
+  await Bun.write(path, JSON.stringify(credentials, null, 2));
+
+  if (process.platform !== "win32") {
+    await chmod(path, 0o600);
+  }
+};
+
+export const loadCredentials = async (): Promise<Credentials | null> => {
+  const file = Bun.file(credentialsPath());
+
+  if (!(await file.exists())) {
+    return null;
+  }
+
+  return (await file.json()) as Credentials;
+};

--- a/apps/cli/src/lib/update.ts
+++ b/apps/cli/src/lib/update.ts
@@ -1,0 +1,109 @@
+import { join } from "node:path";
+import { colors } from "@bunli/utils";
+import packageJson from "../../package.json";
+import { GITHUB_REPO } from "./config";
+import { configDir } from "./credentials";
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CLI_TAG_PREFIX = "cli-v";
+
+interface UpdateCheckState {
+  lastCheckedAt: number;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  draft: boolean;
+  assets: { name: string; browser_download_url: string }[];
+}
+
+const stateFilePath = (): string => join(configDir(), "update-check.json");
+
+const readState = async (): Promise<UpdateCheckState | null> => {
+  const file = Bun.file(stateFilePath());
+
+  if (!(await file.exists())) {
+    return null;
+  }
+
+  return (await file.json()) as UpdateCheckState;
+};
+
+const writeState = async (state: UpdateCheckState): Promise<void> => {
+  await Bun.write(stateFilePath(), JSON.stringify(state));
+};
+
+/**
+ * This is a monorepo — web/mobile publish their own `v*`-tagged releases,
+ * so `/releases/latest` would return whichever of those is newest instead
+ * of the latest CLI release. List releases and find the newest `cli-v*` one.
+ */
+export const getLatestRelease = async (): Promise<GithubRelease | null> => {
+  const response = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30`,
+    { signal: AbortSignal.timeout(5000) }
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const releases = (await response.json()) as GithubRelease[];
+
+  return (
+    releases.find(
+      (release) => !release.draft && release.tag_name.startsWith(CLI_TAG_PREFIX)
+    ) ?? null
+  );
+};
+
+export const versionFromTag = (tagName: string): string =>
+  tagName.startsWith(CLI_TAG_PREFIX)
+    ? tagName.slice(CLI_TAG_PREFIX.length)
+    : tagName;
+
+export const getAssetNameForPlatform = (): string => {
+  if (process.platform === "darwin") {
+    return process.arch === "arm64" ? "bahar-darwin-arm64" : "bahar-darwin-x64";
+  }
+
+  if (process.platform === "win32") {
+    return "bahar-windows-x64.exe";
+  }
+
+  return "bahar-linux-x64";
+};
+
+/**
+ * Notify-only check, run on every invocation. Never throws — a failed
+ * or rate-limited check should never block the command the user asked for.
+ */
+export const checkForUpdate = async (): Promise<void> => {
+  try {
+    const state = await readState();
+
+    if (state && Date.now() - state.lastCheckedAt < CHECK_INTERVAL_MS) {
+      return;
+    }
+
+    await writeState({ lastCheckedAt: Date.now() });
+
+    const release = await getLatestRelease();
+
+    if (!release) {
+      return;
+    }
+
+    const latestVersion = versionFromTag(release.tag_name);
+
+    if (latestVersion !== packageJson.version) {
+      console.log(
+        colors.yellow(
+          `A new version of the Bahar CLI is available (${latestVersion}). Run \`bahar update\` to upgrade.`
+        )
+      );
+    }
+  } catch {
+    // Update checks should never block usage.
+  }
+};

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@bahar/typescript-config/trpc.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,7 @@
 import { polarClient } from "@polar-sh/better-auth/client";
 import {
   adminClient,
+  apiKeyClient,
   emailOTPClient,
   inferAdditionalFields,
 } from "better-auth/client/plugins";
@@ -14,6 +15,7 @@ export const authClient = createAuthClient({
     inferAdditionalFields<typeof auth>(),
     emailOTPClient(),
     adminClient(),
+    apiKeyClient(),
     polarClient(),
   ],
   fetchOptions: {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { createFileRoute } from '@tanstack/react-router'
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
+import { Route as CliAuthRouteImport } from './routes/cli-auth/route'
 import { Route as UnauthorizedLayoutRouteImport } from './routes/_unauthorized-layout/route'
 import { Route as AuthorizedLayoutRouteImport } from './routes/_authorized-layout/route'
 import { Route as UnauthorizedLayoutLoginRouteImport } from './routes/_unauthorized-layout/login/route'
@@ -43,6 +44,14 @@ const AuthorizedLayoutAppLayoutDictionaryAddRouteLazyImport = createFileRoute(
 )()
 
 // Create/Update Routes
+
+const CliAuthRouteRoute = CliAuthRouteImport.update({
+  id: '/cli-auth',
+  path: '/cli-auth',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/cli-auth/route.lazy').then((d) => d.Route),
+)
 
 const UnauthorizedLayoutRouteRoute = UnauthorizedLayoutRouteImport.update({
   id: '/_unauthorized-layout',
@@ -173,6 +182,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: ''
       preLoaderRoute: typeof UnauthorizedLayoutRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/cli-auth': {
+      id: '/cli-auth'
+      path: '/cli-auth'
+      fullPath: '/cli-auth'
+      preLoaderRoute: typeof CliAuthRouteImport
       parentRoute: typeof rootRoute
     }
     '/_authorized-layout/_app-layout': {
@@ -337,6 +353,7 @@ const UnauthorizedLayoutRouteRouteWithChildren =
 
 export interface FileRoutesByFullPath {
   '': typeof AuthorizedLayoutSearchLayoutRouteRouteWithChildren
+  '/cli-auth': typeof CliAuthRouteRoute
   '/goodbye': typeof UnauthorizedLayoutGoodbyeRouteRoute
   '/login': typeof UnauthorizedLayoutLoginRouteRoute
   '/checkout-success': typeof AuthorizedLayoutAppLayoutCheckoutSuccessRouteLazyRoute
@@ -350,6 +367,7 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   '': typeof AuthorizedLayoutAppLayoutRouteRouteWithChildren
+  '/cli-auth': typeof CliAuthRouteRoute
   '/goodbye': typeof UnauthorizedLayoutGoodbyeRouteRoute
   '/login': typeof UnauthorizedLayoutLoginRouteRoute
   '/checkout-success': typeof AuthorizedLayoutAppLayoutCheckoutSuccessRouteLazyRoute
@@ -365,6 +383,7 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/_authorized-layout': typeof AuthorizedLayoutRouteRouteWithChildren
   '/_unauthorized-layout': typeof UnauthorizedLayoutRouteRouteWithChildren
+  '/cli-auth': typeof CliAuthRouteRoute
   '/_authorized-layout/_app-layout': typeof AuthorizedLayoutAppLayoutRouteRouteWithChildren
   '/_authorized-layout/_search-layout': typeof AuthorizedLayoutSearchLayoutRouteRouteWithChildren
   '/_unauthorized-layout/goodbye': typeof UnauthorizedLayoutGoodbyeRouteRoute
@@ -382,6 +401,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | ''
+    | '/cli-auth'
     | '/goodbye'
     | '/login'
     | '/checkout-success'
@@ -394,6 +414,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | ''
+    | '/cli-auth'
     | '/goodbye'
     | '/login'
     | '/checkout-success'
@@ -407,6 +428,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_authorized-layout'
     | '/_unauthorized-layout'
+    | '/cli-auth'
     | '/_authorized-layout/_app-layout'
     | '/_authorized-layout/_search-layout'
     | '/_unauthorized-layout/goodbye'
@@ -424,11 +446,13 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   AuthorizedLayoutRouteRoute: typeof AuthorizedLayoutRouteRouteWithChildren
   UnauthorizedLayoutRouteRoute: typeof UnauthorizedLayoutRouteRouteWithChildren
+  CliAuthRouteRoute: typeof CliAuthRouteRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   AuthorizedLayoutRouteRoute: AuthorizedLayoutRouteRouteWithChildren,
   UnauthorizedLayoutRouteRoute: UnauthorizedLayoutRouteRouteWithChildren,
+  CliAuthRouteRoute: CliAuthRouteRoute,
 }
 
 export const routeTree = rootRoute
@@ -442,7 +466,8 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/_authorized-layout",
-        "/_unauthorized-layout"
+        "/_unauthorized-layout",
+        "/cli-auth"
       ]
     },
     "/_authorized-layout": {
@@ -458,6 +483,9 @@ export const routeTree = rootRoute
         "/_unauthorized-layout/goodbye",
         "/_unauthorized-layout/login"
       ]
+    },
+    "/cli-auth": {
+      "filePath": "cli-auth/route.tsx"
     },
     "/_authorized-layout/_app-layout": {
       "filePath": "_authorized-layout/_app-layout/route.tsx",

--- a/apps/web/src/routes/cli-auth/route.lazy.tsx
+++ b/apps/web/src/routes/cli-auth/route.lazy.tsx
@@ -1,0 +1,60 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { AnimatedLogo } from "@/components/AnimatedLogo";
+import { Page } from "@/components/Page";
+import { authClient } from "@/lib/auth-client";
+
+type MintStatus = "minting" | "done" | "error";
+
+const CliAuth = () => {
+  const { port, state } = Route.useSearch();
+  const [status, setStatus] = useState<MintStatus>("minting");
+
+  useEffect(() => {
+    const mintAndRedirect = async () => {
+      const { data, error } = await authClient.apiKey.create({
+        name: "CLI",
+      });
+
+      if (error || !data) {
+        setStatus("error");
+        return;
+      }
+
+      const callbackUrl = new URL(`http://localhost:${port}/callback`);
+      callbackUrl.searchParams.set("token", data.key);
+      callbackUrl.searchParams.set("state", state);
+
+      setStatus("done");
+      window.location.href = callbackUrl.toString();
+    };
+
+    mintAndRedirect();
+  }, [port, state]);
+
+  return (
+    <Page className="mx-auto flex max-w-96 flex-col items-center justify-center gap-y-6 text-center">
+      {status !== "error" && <AnimatedLogo className="h-16 w-16" />}
+
+      <h1 className="font-bold text-2xl tracking-tight">
+        {status === "error" ? (
+          <Trans>Something went wrong</Trans>
+        ) : (
+          <Trans>Signing in the Bahar CLI...</Trans>
+        )}
+      </h1>
+
+      <p className="text-muted-foreground text-sm">
+        {status === "error"
+          ? t`Please return to your terminal and run \`bahar login\` again.`
+          : t`You can close this tab once your terminal shows you're signed in.`}
+      </p>
+    </Page>
+  );
+};
+
+export const Route = createLazyFileRoute("/cli-auth")({
+  component: CliAuth,
+});

--- a/apps/web/src/routes/cli-auth/route.tsx
+++ b/apps/web/src/routes/cli-auth/route.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { authClient } from "@/lib/auth-client";
+
+type CliAuthSearch = {
+  port: number;
+  state: string;
+};
+
+export const Route = createFileRoute("/cli-auth")({
+  validateSearch: (search: Record<string, unknown>): CliAuthSearch => ({
+    port: Number(search.port),
+    state: String(search.state ?? ""),
+  }),
+  beforeLoad: async ({ location }) => {
+    const { data } = await authClient.getSession();
+
+    if (!data?.user) {
+      throw redirect({ to: "/login", search: { redirect: location.href } });
+    }
+  },
+});

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -18,6 +18,14 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
+  "overrides": [
+    {
+      "includes": ["apps/cli/**"],
+      "javascript": {
+        "globals": ["Bun"]
+      }
+    }
+  ],
   "linter": {
     "rules": {
       "a11y": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 0.10.0
       '@polar-sh/better-auth':
         specifier: ^1.8.3
-        version: 1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6)
+        version: 1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6)
       '@polar-sh/sdk':
         specifier: ^0.47.0
         version: 0.47.0
@@ -112,6 +112,25 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+
+  apps/cli:
+    dependencies:
+      '@bunli/core':
+        specifier: 0.1.0
+        version: 0.1.0(bun@1.3.14)
+      open:
+        specifier: ^10.1.0
+        version: 10.2.0
+    devDependencies:
+      '@bahar/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/config-typescript
+      bun-types:
+        specifier: ^1.3.5
+        version: 1.3.11
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
 
   apps/marketing:
     dependencies:
@@ -226,7 +245,7 @@ importers:
         version: 3.1.16
       '@polar-sh/better-auth':
         specifier: ^1.8.1
-        version: 1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6)
+        version: 1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.81.5)
@@ -3568,6 +3587,28 @@ packages:
 
   /@borewit/text-codec@0.2.2:
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+    dev: false
+
+  /@bunli/core@0.1.0(bun@1.3.14):
+    resolution: {integrity: sha512-+1hZ3cLgFLbpXndHhxZDkGNYj8zLvxmTSW4y+Kna6sJXI/L1lKaQGZBzu8+LmUckG+25BMydgocP59yaRURRag==}
+    engines: {bun: '>=1.0.0'}
+    dependencies:
+      '@bunli/utils': 0.1.0(bun@1.3.14)
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+    transitivePeerDependencies:
+      - bun
+    dev: false
+
+  /@bunli/utils@0.1.0(bun@1.3.14):
+    resolution: {integrity: sha512-2KR4ZWhkFzRR4PYc9FB0Y738Xle98Heyr8se6YK+vetDXxhlBiM4W2WZ7IBHmZn12PcXedc5DBvDjrvOdXXv/Q==}
+    engines: {bun: '>=1.0.0'}
+    peerDependencies:
+      bun: '>=1.0.0'
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      bun: 1.3.14
     dev: false
 
   /@capsizecss/unpack@3.0.1:
@@ -7782,6 +7823,134 @@ packages:
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
     dev: false
 
+  /@oven/bun-darwin-aarch64@1.3.14:
+    resolution: {integrity: sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-darwin-x64-baseline@1.3.14:
+    resolution: {integrity: sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-darwin-x64@1.3.14:
+    resolution: {integrity: sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-freebsd-aarch64@1.3.14:
+    resolution: {integrity: sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-freebsd-x64@1.3.14:
+    resolution: {integrity: sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-aarch64-android@1.3.14:
+    resolution: {integrity: sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-aarch64-musl@1.3.14:
+    resolution: {integrity: sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-aarch64@1.3.14:
+    resolution: {integrity: sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-x64-android@1.3.14:
+    resolution: {integrity: sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg==}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-x64-baseline@1.3.14:
+    resolution: {integrity: sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-x64-musl-baseline@1.3.14:
+    resolution: {integrity: sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-x64-musl@1.3.14:
+    resolution: {integrity: sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-linux-x64@1.3.14:
+    resolution: {integrity: sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-windows-aarch64@1.3.14:
+    resolution: {integrity: sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-windows-x64-baseline@1.3.14:
+    resolution: {integrity: sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@oven/bun-windows-x64@1.3.14:
+    resolution: {integrity: sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -7812,7 +7981,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/better-auth@1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6):
+  /@polar-sh/better-auth@1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6):
     resolution: {integrity: sha512-wZjF1xcxw1+blnR8JspPwZ0WhwoHkG4C2oFhVzb1RJKQfwTBjSmnrBftjaV6D3WFHDnrs0wFPnW/YHXzg8paOA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7820,7 +7989,7 @@ packages:
       better-auth: ^1.4.12
       zod: ^3.24.2 || ^4
     dependencies:
-      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
+      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
       '@polar-sh/sdk': 0.42.5
       better-auth: 1.4.19(drizzle-orm@0.45.1)(react-dom@19.1.0)(react@19.1.0)
       zod: 4.3.6
@@ -7835,7 +8004,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/better-auth@1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6):
+  /@polar-sh/better-auth@1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6):
     resolution: {integrity: sha512-9lASF4si+iU3pi3yNVhb+uZdqF7ZvF7J7GSq0w6YaZsr/oVXxd4l+v8cmJiq3crsEaXiJIBni6v3xHpzgCjtmQ==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7843,7 +8012,7 @@ packages:
       better-auth: ^1.4.12
       zod: ^3.24.2 || ^4
     dependencies:
-      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
+      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
       '@polar-sh/sdk': 0.47.0
       better-auth: 1.4.19(drizzle-kit@0.31.9)(drizzle-orm@0.45.1)(react-dom@19.1.0)(react@19.1.0)
       zod: 4.3.6
@@ -7882,7 +8051,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
+  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
     resolution: {integrity: sha512-lkHa7JJtQpbHblsfpEX91bJRV6s7gyBIlehVCy2KRL89vP4t6t2vYKNwIxIHI+EG7RxXKu/4fCMchQYrVSMYuQ==}
     peerDependencies:
       '@stripe/react-stripe-js': ^3.6.0 || ^4.0.2
@@ -7890,7 +8059,7 @@ packages:
       react: 19.1.0
     dependencies:
       '@polar-sh/sdk': 0.42.5
-      '@polar-sh/ui': 0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
+      '@polar-sh/ui': 0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
       '@stripe/react-stripe-js': 4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react@19.1.0)
       '@stripe/stripe-js': 7.9.0
       event-source-plus: 0.1.15
@@ -7906,7 +8075,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
+  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
     resolution: {integrity: sha512-lkHa7JJtQpbHblsfpEX91bJRV6s7gyBIlehVCy2KRL89vP4t6t2vYKNwIxIHI+EG7RxXKu/4fCMchQYrVSMYuQ==}
     peerDependencies:
       '@stripe/react-stripe-js': ^3.6.0 || ^4.0.2
@@ -7914,7 +8083,7 @@ packages:
       react: 19.1.0
     dependencies:
       '@polar-sh/sdk': 0.42.5
-      '@polar-sh/ui': 0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
+      '@polar-sh/ui': 0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
       '@stripe/react-stripe-js': 4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react@19.1.0)
       '@stripe/stripe-js': 7.9.0
       event-source-plus: 0.1.15
@@ -7989,7 +8158,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/ui@0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
+  /@polar-sh/ui@0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
     resolution: {integrity: sha512-YTmMB2lr+PplMTDZnTs0Crgu0KNBKyQcSX4N0FYXSlo1Q6e9IKs4hwzEcqNUv3eHS4BxGO1SvxxNjuSK+il49Q==}
     peerDependencies:
       react: 19.1.0
@@ -8034,7 +8203,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/ui@0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
+  /@polar-sh/ui@0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
     resolution: {integrity: sha512-YTmMB2lr+PplMTDZnTs0Crgu0KNBKyQcSX4N0FYXSlo1Q6e9IKs4hwzEcqNUv3eHS4BxGO1SvxxNjuSK+il49Q==}
     peerDependencies:
       react: 19.1.0
@@ -15273,6 +15442,38 @@ packages:
     dependencies:
       '@types/node': 20.10.6
 
+  /bun@1.3.14:
+    resolution: {integrity: sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, android, freebsd, win32]
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.14
+      '@oven/bun-darwin-x64': 1.3.14
+      '@oven/bun-darwin-x64-baseline': 1.3.14
+      '@oven/bun-freebsd-aarch64': 1.3.14
+      '@oven/bun-freebsd-x64': 1.3.14
+      '@oven/bun-linux-aarch64': 1.3.14
+      '@oven/bun-linux-aarch64-android': 1.3.14
+      '@oven/bun-linux-aarch64-musl': 1.3.14
+      '@oven/bun-linux-x64': 1.3.14
+      '@oven/bun-linux-x64-android': 1.3.14
+      '@oven/bun-linux-x64-baseline': 1.3.14
+      '@oven/bun-linux-x64-musl': 1.3.14
+      '@oven/bun-linux-x64-musl-baseline': 1.3.14
+      '@oven/bun-windows-aarch64': 1.3.14
+      '@oven/bun-windows-x64': 1.3.14
+      '@oven/bun-windows-x64-baseline': 1.3.14
+    dev: false
+
+  /bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      run-applescript: 7.1.0
+    dev: false
+
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -16219,6 +16420,19 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  /default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+    dev: false
+
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
@@ -16235,6 +16449,11 @@ packages:
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -19320,6 +19539,7 @@ packages:
   /is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
+    hasBin: true
 
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -22619,6 +22839,16 @@ packages:
       regex-recursion: 6.0.2
     dev: false
 
+  /open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+    dev: false
+
   /open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
@@ -24402,6 +24632,11 @@ packages:
 
   /rtl-detect@1.1.2:
     resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
+    dev: false
+
+  /run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
     dev: false
 
   /run-async@2.4.1:
@@ -27179,6 +27414,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  /wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+    dependencies:
+      is-wsl: 3.1.0
+    dev: false
 
   /xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}


### PR DESCRIPTION
Adds a standalone bunli-based CLI (apps/cli) so an agent or user can query their own Bahar dictionary/flashcard data directly against their per-user Turso database, bypassing the need for a new REST API surface.

- Registers Better Auth's apiKey plugin (bahar_cli_ prefix) so the CLI can hold a real revocable PAT instead of a raw session token.
- New /cli-auth web page: browser-based login flow mints a key and redirects to the CLI's localhost callback server (loopback pattern, à la gh/vercel).
- bahar login / bahar db-info / bahar update commands, plus a passive update-check on every run.
- Release workflow cross-compiles all 4 platform binaries from a single ubuntu runner and publishes to GitHub Releases on cli-v* tags (scoped explicitly, since this monorepo's other apps already use plain v* tags).
- install.sh / install.ps1 for distribution via raw.githubusercontent.com.
- .claude/skills/bahar-data-access documents the flow for agents, pointing at live schema introspection rather than a hardcoded (and driftable) column list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI with login, database info, and update commands.
  * Introduced one-line install scripts for macOS/Linux and Windows.
  * Added browser-based CLI sign-in flow and a new authorization page.

* **Bug Fixes**
  * Improved CLI update checks and in-place binary updates for the right platform.
  * Added support for API-key-based access across the app.

* **Chores**
  * Added release automation for CLI binaries and related build/config updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->