### PR TITLE
feat(cli): flashcard grading + version/help commands

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,8 +14,15 @@
     "dev": "bun run src/index.ts"
   },
   "dependencies": {
+    "@bahar/db-operations": "workspace:*",
+    "@bahar/drizzle-user-db-schemas": "workspace:*",
+    "@bahar/fsrs": "workspace:*",
     "@bunli/core": "0.1.0",
-    "open": "^10.1.0"
+    "@libsql/client": "^0.17.0",
+    "date-fns": "^4.1.0",
+    "drizzle-orm": "^0.45.1",
+    "open": "^10.1.0",
+    "ts-fsrs": "^5.2.3"
   },
   "devDependencies": {
     "@bahar/typescript-config": "workspace:*",

--- a/apps/cli/skill/SKILL.md
+++ b/apps/cli/skill/SKILL.md
@@ -13,6 +13,39 @@ description: >
 
 # Bahar data access (for agents)
 
+## Supported actions — and nothing else
+
+You may perform **only** these write actions against the user's database:
+
+1. **Add words** — insert new `dictionary_entries` (and, if asked, their `flashcards`).
+2. **Edit words** — update fields on existing `dictionary_entries` (word, translation,
+   definition, tags, examples, etc.).
+3. **Grade flashcards** — record a spaced-repetition review, **only** via the `bahar grade`
+   command (see "Grading flashcards" below). Never hand-write FSRS fields.
+4. **Manage decks** — full CRUD on `decks` (create, rename, edit filters, delete). Safe:
+   a deck is just a saved filter config (`id`, `name`, `filters`), and `flashcards` hold
+   no reference to it, so deleting a deck only removes that grouping — no card or review
+   data is affected.
+
+Reading/querying anything for lookup, search, or study-coaching is always fine.
+
+**Anything not on this list is unsupported and may cause irreversible damage to the user's
+database. Assume there is no undo.** Do not do it even if the user asks, without first
+warning them of the consequences and getting explicit confirmation. Unsupported includes
+(non-exhaustive):
+
+- **Deleting flashcards or `dictionary_entries`** — deleting an entry cascades to delete
+  its flashcards and permanently loses their FSRS review history. (Deleting *decks* is
+  fine — see supported actions above.)
+- **Hand-editing FSRS scheduling fields** (`due`, `state`, `stability`, `difficulty`,
+  `reps`, `lapses`, …) — desyncs the schedule. Use `bahar grade`.
+- **Editing `user_stats` / streak directly** — `bahar grade` maintains these.
+- **Touching the `migrations` table, or any DDL** (`DROP`/`ALTER`/`CREATE`) — breaks
+  schema versioning and cross-device sync.
+- **Changing primary keys** or the `(dictionary_entry_id, direction)` uniqueness on
+  `flashcards` — breaks sync.
+- **Bulk writes without a precise `WHERE`.**
+
 ## Where the data lives
 
 Each Bahar user has their own personal SQLite database, hosted on Turso, separate from
@@ -93,11 +126,33 @@ per Step 4.
   language's equivalent) it yourself.
 - `flashcards` scheduling fields (`difficulty`, `stability`, `due`, `state`, `reps`,
   `lapses`, etc.) are FSRS spaced-repetition algorithm state, not plain data. Reading
-  them for study-coaching purposes is safe. Writing a new review result requires
-  running the actual FSRS scheduling algorithm to compute the next values — don't
-  hand-write a new `due`/`state` directly, it will desync the schedule. If you can't
-  run the real FSRS algorithm, stick to additive writes only (new dictionary entries,
-  new flashcards/decks) and leave grading to the app itself.
+  them for study-coaching purposes is safe. **Never write them by hand** — a review must
+  run the real FSRS algorithm (and also update the streak in `user_stats`), so always go
+  through `bahar grade` (see below) rather than issuing your own `UPDATE`.
 - The `access_token` from `bahar db-info` is a real credential scoped to that user's
   database. Treat it like a password — don't print it to logs or persist it anywhere
   beyond what's needed to make the connection.
+
+## Grading flashcards
+
+Grading is the one write you must **not** do with your own SQL — it needs the real FSRS
+algorithm plus a streak update. Use the CLI exclusively, which owns both:
+
+```bash
+# Grade + persist: runs FSRS, updates the flashcard, updates the streak
+bahar grade <card-id> good        # one of: again | hard | good | easy
+
+# Full usage
+bahar grade help
+```
+
+Typical review flow:
+
+1. Query due cards directly (`flashcards` where the card is due now and not hidden),
+   joining `dictionary_entries` for the word/translation to quiz on.
+2. Show the word to the user.
+3. When they answer, run `bahar grade <card-id> <again|hard|good|easy>` — the CLI writes
+   the flashcard and streak for you.
+
+Never build your own `UPDATE flashcards` for a review, and never edit `user_stats` /
+streak yourself — `bahar grade` is the only supported path.

--- a/apps/cli/src/commands/grade.ts
+++ b/apps/cli/src/commands/grade.ts
@@ -1,0 +1,141 @@
+import {
+  flashcards,
+  type SelectFlashcard,
+} from "@bahar/drizzle-user-db-schemas";
+import { createScheduler, getSchedulingOptions } from "@bahar/fsrs";
+import { defineCommand } from "@bunli/core";
+import { eq } from "drizzle-orm";
+import { type Grade, Rating } from "ts-fsrs";
+import { loadCredentials } from "../lib/credentials";
+import { connectUserDb } from "../lib/db";
+import { postRevlog } from "../lib/revlog";
+import { recordReview } from "../lib/streak";
+
+const GRADE_BY_LABEL: Record<string, Grade> = {
+  again: Rating.Again,
+  hard: Rating.Hard,
+  good: Rating.Good,
+  easy: Rating.Easy,
+};
+
+const GRADE_LABELS = Object.keys(GRADE_BY_LABEL).join(" | ");
+
+const printHelp = () => {
+  console.log(`Grade a flashcard, running the real FSRS scheduler.
+
+Usage:
+  bahar grade <card-id> <grade>    Grade the card and persist: updates the
+                                   flashcard, the streak, and the review log.
+  bahar grade help                 Show this help.
+
+  <grade>   one of: ${GRADE_LABELS}
+
+Find a card's id by querying the user's database directly (see the
+bahar-data-access skill). Never hand-write FSRS fields — always grade here.`);
+};
+
+/**
+ * Builds the flashcard columns to persist from a scheduled FSRS card.
+ * Matches the update the web/mobile apps write on a review.
+ */
+const toFlashcardUpdate = (
+  card: ReturnType<typeof getSchedulingOptions>[Grade]["card"]
+) => ({
+  due: card.due.toISOString(),
+  due_timestamp_ms: card.due.getTime(),
+  last_review: card.last_review?.toISOString() ?? null,
+  last_review_timestamp_ms: card.last_review?.getTime() ?? null,
+  state: card.state,
+  stability: card.stability,
+  difficulty: card.difficulty,
+  reps: card.reps,
+  lapses: card.lapses,
+  elapsed_days: card.elapsed_days,
+  scheduled_days: card.scheduled_days,
+  learning_steps: card.learning_steps,
+});
+
+export const gradeCommand = defineCommand({
+  name: "grade",
+  description: "Grade a flashcard (preview intervals, or grade and persist)",
+  handler: async ({ positional, colors }) => {
+    const [cardId, gradeArg] = positional as string[];
+
+    if (!cardId || cardId === "help") {
+      printHelp();
+      return;
+    }
+
+    if (!gradeArg) {
+      console.error(
+        colors.red(`A grade is required. Use one of: ${GRADE_LABELS}.`)
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const grade = GRADE_BY_LABEL[gradeArg.toLowerCase()];
+    if (grade === undefined) {
+      console.error(
+        colors.red(`Invalid grade "${gradeArg}". Use one of: ${GRADE_LABELS}.`)
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const credentials = await loadCredentials();
+    if (!credentials) {
+      console.error(colors.red("Not logged in. Run `bahar login` first."));
+      process.exitCode = 1;
+      return;
+    }
+
+    const { db, client } = await connectUserDb(credentials.token);
+
+    try {
+      const [card] = (await db
+        .select()
+        .from(flashcards)
+        .where(eq(flashcards.id, cardId))
+        .limit(1)) as SelectFlashcard[];
+
+      if (!card) {
+        console.error(colors.red(`No flashcard found with id "${cardId}".`));
+        process.exitCode = 1;
+        return;
+      }
+
+      const scheduler = createScheduler();
+      const now = new Date();
+      const { card: scheduled, log } = getSchedulingOptions(
+        scheduler,
+        card,
+        now
+      )[grade];
+      const updates = toFlashcardUpdate(scheduled);
+
+      await db.update(flashcards).set(updates).where(eq(flashcards.id, cardId));
+      await recordReview(db);
+
+      // Fire-and-forget like the app — a failed revlog must not fail the grade.
+      await postRevlog({
+        token: credentials.token,
+        log,
+        direction: card.direction,
+        dictionaryEntryId: card.dictionary_entry_id,
+      }).catch((err) => {
+        console.warn(`Failed to post revlog: ${err}`);
+      });
+
+      console.log(
+        JSON.stringify(
+          { id: cardId, grade: gradeArg.toLowerCase(), ...updates },
+          null,
+          2
+        )
+      );
+    } finally {
+      client.close();
+    }
+  },
+});

--- a/apps/cli/src/commands/version.ts
+++ b/apps/cli/src/commands/version.ts
@@ -1,0 +1,10 @@
+import { defineCommand } from "@bunli/core";
+import { CLI_VERSION } from "../lib/config";
+
+export const versionCommand = defineCommand({
+  name: "version",
+  description: "Print the CLI version",
+  handler: () => {
+    console.log(CLI_VERSION);
+  },
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,11 +1,24 @@
 #!/usr/bin/env bun
 import { createCLI } from "@bunli/core";
 import { dbInfoCommand } from "./commands/db-info";
+import { gradeCommand } from "./commands/grade";
 import { loginCommand } from "./commands/login";
 import { skillCommand } from "./commands/skill";
 import { updateCommand } from "./commands/update";
+import { versionCommand } from "./commands/version";
 import { CLI_VERSION } from "./lib/config";
 import { checkForUpdate } from "./lib/update";
+
+const argv = process.argv.slice(2);
+
+if (
+  argv[0] === "version" ||
+  argv.includes("--version") ||
+  argv.includes("-v")
+) {
+  console.log(CLI_VERSION);
+  process.exit(0);
+}
 
 const cli = createCLI({
   name: "bahar",
@@ -16,10 +29,14 @@ const cli = createCLI({
 
 cli.command(loginCommand);
 cli.command(dbInfoCommand);
+cli.command(gradeCommand);
 cli.command(updateCommand);
 cli.command(skillCommand);
+cli.command(versionCommand);
 
 await checkForUpdate();
 
 await cli.init();
-await cli.run();
+
+// `bahar help` mirrors the built-in `--help` output.
+await cli.run(argv[0] === "help" ? ["--help"] : undefined);

--- a/apps/cli/src/lib/db.ts
+++ b/apps/cli/src/lib/db.ts
@@ -1,0 +1,39 @@
+import * as schema from "@bahar/drizzle-user-db-schemas";
+import { type Client, createClient } from "@libsql/client/web";
+import { drizzle } from "drizzle-orm/libsql/web";
+import { API_URL } from "./config";
+
+export type UserDb = ReturnType<typeof drizzle<typeof schema>>;
+
+type UserDatabaseInfo = {
+  hostname: string;
+  access_token: string;
+};
+
+/**
+ * Opens a remote-only connection to the user's personal Turso database.
+ *
+ * Uses the fetch-based `@libsql/client/web` client so the CLI stays free of
+ * native bindings and embeds cleanly in the compiled binary — no embedded
+ * replica, no sync.
+ */
+export const connectUserDb = async (
+  token: string
+): Promise<{ db: UserDb; client: Client }> => {
+  const response = await fetch(new URL("/databases/user", API_URL), {
+    headers: { "x-api-key": token },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch database info (${response.status}).`);
+  }
+
+  const info = (await response.json()) as UserDatabaseInfo;
+
+  const client = createClient({
+    url: `libsql://${info.hostname}`,
+    authToken: info.access_token,
+  });
+
+  return { db: drizzle(client, { schema }), client };
+};

--- a/apps/cli/src/lib/revlog.ts
+++ b/apps/cli/src/lib/revlog.ts
@@ -1,0 +1,42 @@
+import type { FlashcardDirection } from "@bahar/drizzle-user-db-schemas";
+import { type Grade, Rating, type ReviewLog } from "ts-fsrs";
+import { API_URL } from "./config";
+
+const RATING_TO_LABEL: Record<Grade, "again" | "hard" | "good" | "easy"> = {
+  [Rating.Again]: "again",
+  [Rating.Hard]: "hard",
+  [Rating.Good]: "good",
+  [Rating.Easy]: "easy",
+};
+
+/**
+ * Posts a review-log entry to the server-side stats table (central API DB,
+ * keyed by user). Mirrors the mobile app's fire-and-forget revlog post.
+ */
+export const postRevlog = async ({
+  token,
+  log,
+  direction,
+  dictionaryEntryId,
+}: {
+  token: string;
+  log: ReviewLog;
+  direction: FlashcardDirection;
+  dictionaryEntryId: string;
+}): Promise<void> => {
+  await fetch(new URL("/stats/revlogs", API_URL), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": token,
+    },
+    body: JSON.stringify({
+      ...log,
+      due: log.due.toISOString(),
+      review: log.review.toISOString(),
+      rating: RATING_TO_LABEL[log.rating as Grade],
+      direction,
+      dictionary_entry_id: dictionaryEntryId,
+    }),
+  });
+};

--- a/apps/cli/src/lib/streak.test.ts
+++ b/apps/cli/src/lib/streak.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import * as schema from "@bahar/drizzle-user-db-schemas";
+import { type Client, createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import type { UserDb } from "./db";
+import { recordReview } from "./streak";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// In-memory user DB per test.
+let client: Client;
+let db: UserDb;
+
+beforeEach(async () => {
+  client = createClient({ url: ":memory:" });
+  db = drizzle(client, { schema });
+
+  await client.execute(
+    `CREATE TABLE user_stats (
+      id text PRIMARY KEY NOT NULL,
+      streak_count integer DEFAULT 0,
+      longest_streak integer DEFAULT 0,
+      last_review_date text,
+      timezone text
+    )`
+  );
+  // TODO: also CREATE TABLE flashcards (columns per schema) for the gap tests.
+});
+
+// Helper: seed a user_stats row with a given last_review_date / streak.
+// Helper: insert flashcards with specific due_timestamp_ms / is_hidden.
+// Note: recordReview reads the system clock + timezone, so seed
+// last_review_date relative to the real today/yesterday.
+
+describe("recordReview", () => {
+  test("no user_stats row -> inserts streak=1 for today", async () => {
+    await recordReview(db);
+
+    const { rows } = await client.execute("SELECT * FROM user_stats");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].streak_count).toBe(1);
+    expect(rows[0].longest_streak).toBe(1);
+    expect(rows[0].last_review_date).toMatch(ISO_DATE_RE);
+  });
+
+  test("already reviewed today -> no-op (streak unchanged)", async () => {
+    // Given: last_review_date === today, streak_count=5
+    // When:  recordReview(db)
+    // Then:  streak_count still 5, last_review_date still today
+  });
+
+  test("last review was yesterday -> streak increments", async () => {
+    // Given: last_review_date === yesterday, streak_count=5
+    // When:  recordReview(db)
+    // Then:  streak_count=6, last_review_date=today, longest_streak>=6
+  });
+
+  test("gap with no due cards missed -> streak forgiven (increments)", async () => {
+    // Given: last_review_date = 3 days ago, streak_count=5,
+    //        NO flashcards came due during the gap
+    // When:  recordReview(db)
+    // Then:  streak_count=6 (forgiven, not reset)
+  });
+
+  test("gap with due cards missed -> streak resets to 1", async () => {
+    // Given: last_review_date = 3 days ago, streak_count=5,
+    //        a flashcard was due (and not hidden) during the gap
+    // When:  recordReview(db)
+    // Then:  streak_count=1
+  });
+
+  test("hidden due cards in the gap do not break the streak", async () => {
+    // Given: the only card due in the gap has is_hidden=true
+    // When:  recordReview(db)
+    // Then:  streak forgiven (increments), not reset
+  });
+
+  test("longest_streak only grows, never shrinks", async () => {
+    // Given: longest_streak=10, current streak resets to 1
+    // When:  recordReview(db)
+    // Then:  longest_streak still 10
+  });
+});

--- a/apps/cli/src/lib/streak.ts
+++ b/apps/cli/src/lib/streak.ts
@@ -1,0 +1,166 @@
+/**
+ * Daily-streak update run after a flashcard grade.
+ *
+ * Copied from apps/mobile/src/lib/db/operations/progress.ts (`recordReview`)
+ * so the CLI keeps the streak consistent with the app. This is a deliberate
+ * third copy — see BAH-153 for extracting it into a shared package.
+ */
+
+import { generateId } from "@bahar/db-operations";
+import {
+  flashcards,
+  type SelectUserStats,
+  userStats,
+} from "@bahar/drizzle-user-db-schemas";
+import { endOfDay, startOfDay } from "date-fns";
+import { and, count, eq, gte, lte } from "drizzle-orm";
+import type { UserDb } from "./db";
+
+const getDeviceTimezone = (): string =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const isValidTimezone = (tz: string): boolean => {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const resolveTimezone = (stored: string | null | undefined): string =>
+  stored && isValidTimezone(stored) ? stored : getDeviceTimezone();
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidDateString = (s: string | null | undefined): s is string =>
+  !!s && ISO_DATE_RE.test(s);
+
+const formatDateInTz = ({
+  date,
+  timezone,
+}: {
+  date: Date;
+  timezone: string;
+}) => {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+};
+
+const getToday = (timezone: string) =>
+  formatDateInTz({ date: new Date(), timezone });
+
+const getYesterday = (timezone: string) => {
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  return formatDateInTz({ date: oneDayAgo, timezone });
+};
+
+const hasDueCardsInGap = async ({
+  db,
+  lastReviewDate,
+  today,
+}: {
+  db: UserDb;
+  lastReviewDate: string;
+  today: string;
+}): Promise<boolean> => {
+  const [yStart, mStart, dStart] = lastReviewDate.split("-").map(Number);
+  const [yEnd, mEnd, dEnd] = today.split("-").map(Number);
+  const gapStart = new Date(yStart, mStart - 1, dStart);
+  gapStart.setDate(gapStart.getDate() + 1);
+  const gapEnd = new Date(yEnd, mEnd - 1, dEnd);
+  gapEnd.setDate(gapEnd.getDate() - 1);
+  if (gapEnd < gapStart) return false;
+
+  const startMs = startOfDay(gapStart).getTime();
+  const endMs = endOfDay(gapEnd).getTime();
+
+  const [result] = await db
+    .select({ c: count() })
+    .from(flashcards)
+    .where(
+      and(
+        gte(flashcards.due_timestamp_ms, startMs),
+        lte(flashcards.due_timestamp_ms, endMs),
+        eq(flashcards.is_hidden, false)
+      )
+    );
+  return (result?.c ?? 0) > 0;
+};
+
+/**
+ * Records that a review happened today and advances the streak.
+ */
+export const recordReview = async (db: UserDb): Promise<void> => {
+  const [row] = (await db
+    .select()
+    .from(userStats)
+    .limit(1)) as SelectUserStats[];
+
+  if (!row) {
+    const timezone = getDeviceTimezone();
+    await db.insert(userStats).values({
+      id: generateId(),
+      streak_count: 1,
+      longest_streak: 1,
+      last_review_date: getToday(timezone),
+      timezone,
+    });
+    return;
+  }
+
+  const timezone = resolveTimezone(row.timezone);
+  const today = getToday(timezone);
+  const yesterday = getYesterday(timezone);
+  const lastReview = isValidDateString(row.last_review_date)
+    ? row.last_review_date
+    : null;
+
+  if (lastReview === today) {
+    if (row.timezone !== timezone) {
+      await db
+        .update(userStats)
+        .set({ timezone })
+        .where(eq(userStats.id, row.id));
+    }
+    return;
+  }
+
+  const currentStreak = row.streak_count ?? 0;
+  const longestStreak = row.longest_streak ?? 0;
+
+  let newStreak: number;
+  if (lastReview === yesterday) {
+    newStreak = currentStreak + 1;
+  } else if (lastReview && lastReview < yesterday) {
+    const hadDueInGap = await hasDueCardsInGap({
+      db,
+      lastReviewDate: lastReview,
+      today,
+    });
+    newStreak = hadDueInGap ? 1 : currentStreak + 1;
+  } else if (lastReview === null && currentStreak > 0) {
+    newStreak = currentStreak + 1;
+  } else {
+    newStreak = 1;
+  }
+
+  const newLongest = Math.max(longestStreak, newStreak);
+
+  await db
+    .update(userStats)
+    .set({
+      streak_count: newStreak,
+      longest_streak: newLongest,
+      last_review_date: today,
+      ...(row.timezone === timezone ? {} : { timezone }),
+    })
+    .where(eq(userStats.id, row.id));
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 0.10.0
       '@polar-sh/better-auth':
         specifier: ^1.8.3
-        version: 1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6)
+        version: 1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6)
       '@polar-sh/sdk':
         specifier: ^0.47.0
         version: 0.47.0
@@ -115,12 +115,33 @@ importers:
 
   apps/cli:
     dependencies:
+      '@bahar/db-operations':
+        specifier: workspace:*
+        version: link:../../packages/db-operations
+      '@bahar/drizzle-user-db-schemas':
+        specifier: workspace:*
+        version: link:../../packages/drizzle-user-db-schemas
+      '@bahar/fsrs':
+        specifier: workspace:*
+        version: link:../../packages/fsrs
       '@bunli/core':
         specifier: 0.1.0
         version: 0.1.0(bun@1.3.14)
+      '@libsql/client':
+        specifier: ^0.17.0
+        version: 0.17.4
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@libsql/client@0.17.4)(bun-types@1.3.11)
       open:
         specifier: ^10.1.0
         version: 10.2.0
+      ts-fsrs:
+        specifier: ^5.2.3
+        version: 5.2.3
     devDependencies:
       '@bahar/typescript-config':
         specifier: workspace:*
@@ -245,7 +266,7 @@ importers:
         version: 3.1.16
       '@polar-sh/better-auth':
         specifier: ^1.8.1
-        version: 1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6)
+        version: 1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.81.5)
@@ -6788,8 +6809,27 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@libsql/client@0.17.4:
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.7.6
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /@libsql/core@0.10.0:
     resolution: {integrity: sha512-rqynAXGaiSpTsykOZdBtI1N4z4O+KZ6mt33K/aHeXAY0gSIfK/ctxuWa0Y1Bjo4FMz1idBTCXz4Ps5kITOvZZw==}
+    dependencies:
+      js-base64: 3.7.6
+    dev: false
+
+  /@libsql/core@0.17.4:
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
     dependencies:
       js-base64: 3.7.6
     dev: false
@@ -6804,6 +6844,14 @@ packages:
 
   /@libsql/darwin-arm64@0.4.1:
     resolution: {integrity: sha512-XICT9/OyU8Aa9Iv1xZIHgvM09n/1OQUk3VC+s5uavzdiGHrDMkOWzN47JN7/FiMa/NWrcgoEiDMk3+e7mE53Ig==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/darwin-arm64@0.5.29:
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -6825,6 +6873,24 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@libsql/darwin-x64@0.5.29:
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/hrana-client@0.10.0:
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.7.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
 
   /@libsql/hrana-client@0.6.2:
     resolution: {integrity: sha512-MWxgD7mXLNf9FXXiM0bc90wCjZSpErWKr5mGza7ERy2FJNNMXd7JIOv+DepBA1FQTIfI8TFO4/QDYgaQC0goNw==}
@@ -6853,6 +6919,22 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@libsql/linux-arm-gnueabihf@0.5.29:
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/linux-arm-musleabihf@0.5.29:
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@libsql/linux-arm64-gnu@0.3.19:
     resolution: {integrity: sha512-mgeAUU1oqqh57k7I3cQyU6Trpdsdt607eFyEmH5QO7dv303ti+LjUvh1pp21QWV6WX7wZyjeJV1/VzEImB+jRg==}
     cpu: [arm64]
@@ -6863,6 +6945,14 @@ packages:
 
   /@libsql/linux-arm64-gnu@0.4.1:
     resolution: {integrity: sha512-9lpvb24tO2qZd9nq5dlq3ESA3hSKYWBIK7lJjfiCM6f7a70AUwBY9QoPJV9q4gILIyVnR1YBGrlm50nnb+dYgw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/linux-arm64-gnu@0.5.29:
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -6885,6 +6975,14 @@ packages:
     dev: false
     optional: true
 
+  /@libsql/linux-arm64-musl@0.5.29:
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@libsql/linux-x64-gnu@0.3.19:
     resolution: {integrity: sha512-2t/J7LD5w2f63wGihEO+0GxfTyYIyLGEvTFEsMO16XI5o7IS9vcSHrxsvAJs4w2Pf907uDjmc7fUfMg6L82BrQ==}
     cpu: [x64]
@@ -6895,6 +6993,14 @@ packages:
 
   /@libsql/linux-x64-gnu@0.4.1:
     resolution: {integrity: sha512-psvuQ3UFBEmDFV8ZHG+WkUHIJiWv+elZ+zIPvOVedlIKdxG1O+8WthWUAhFHOGnbiyzc4sAZ4c3de1oCvyHxyQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/linux-x64-gnu@0.5.29:
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -6917,6 +7023,14 @@ packages:
     dev: false
     optional: true
 
+  /@libsql/linux-x64-musl@0.5.29:
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@libsql/win32-x64-msvc@0.3.19:
     resolution: {integrity: sha512-ay1X9AobE4BpzG0XPw1gplyLZPGHIgJOovvW23gUrukRegiUP62uzhpRbKNogLlUOynyXeq//prHgPXiebUfWg==}
     cpu: [x64]
@@ -6927,6 +7041,14 @@ packages:
 
   /@libsql/win32-x64-msvc@0.4.1:
     resolution: {integrity: sha512-IdODVqV/PrdOnHA/004uWyorZQuRsB7U7bCRCE3vXgABj3eJLJGc6cv2C6ksEaEoVxJbD8k53H4VVAGrtYwXzQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@libsql/win32-x64-msvc@0.5.29:
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -7981,7 +8103,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/better-auth@1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6):
+  /@polar-sh/better-auth@1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6):
     resolution: {integrity: sha512-wZjF1xcxw1+blnR8JspPwZ0WhwoHkG4C2oFhVzb1RJKQfwTBjSmnrBftjaV6D3WFHDnrs0wFPnW/YHXzg8paOA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7989,7 +8111,7 @@ packages:
       better-auth: ^1.4.12
       zod: ^3.24.2 || ^4
     dependencies:
-      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
+      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
       '@polar-sh/sdk': 0.42.5
       better-auth: 1.4.19(drizzle-orm@0.45.1)(react-dom@19.1.0)(react@19.1.0)
       zod: 4.3.6
@@ -8004,7 +8126,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/better-auth@1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6):
+  /@polar-sh/better-auth@1.8.3(@polar-sh/sdk@0.47.0)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(zod@4.3.6):
     resolution: {integrity: sha512-9lASF4si+iU3pi3yNVhb+uZdqF7ZvF7J7GSq0w6YaZsr/oVXxd4l+v8cmJiq3crsEaXiJIBni6v3xHpzgCjtmQ==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -8012,7 +8134,7 @@ packages:
       better-auth: ^1.4.12
       zod: ^3.24.2 || ^4
     dependencies:
-      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
+      '@polar-sh/checkout': 0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
       '@polar-sh/sdk': 0.47.0
       better-auth: 1.4.19(drizzle-kit@0.31.9)(drizzle-orm@0.45.1)(react-dom@19.1.0)(react@19.1.0)
       zod: 4.3.6
@@ -8051,7 +8173,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
+  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
     resolution: {integrity: sha512-lkHa7JJtQpbHblsfpEX91bJRV6s7gyBIlehVCy2KRL89vP4t6t2vYKNwIxIHI+EG7RxXKu/4fCMchQYrVSMYuQ==}
     peerDependencies:
       '@stripe/react-stripe-js': ^3.6.0 || ^4.0.2
@@ -8059,7 +8181,7 @@ packages:
       react: 19.1.0
     dependencies:
       '@polar-sh/sdk': 0.42.5
-      '@polar-sh/ui': 0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
+      '@polar-sh/ui': 0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
       '@stripe/react-stripe-js': 4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react@19.1.0)
       '@stripe/stripe-js': 7.9.0
       event-source-plus: 0.1.15
@@ -8075,7 +8197,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
+  /@polar-sh/checkout@0.2.0(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
     resolution: {integrity: sha512-lkHa7JJtQpbHblsfpEX91bJRV6s7gyBIlehVCy2KRL89vP4t6t2vYKNwIxIHI+EG7RxXKu/4fCMchQYrVSMYuQ==}
     peerDependencies:
       '@stripe/react-stripe-js': ^3.6.0 || ^4.0.2
@@ -8083,7 +8205,7 @@ packages:
       react: 19.1.0
     dependencies:
       '@polar-sh/sdk': 0.42.5
-      '@polar-sh/ui': 0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)
+      '@polar-sh/ui': 0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)
       '@stripe/react-stripe-js': 4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.1.0)(react@19.1.0)
       '@stripe/stripe-js': 7.9.0
       event-source-plus: 0.1.15
@@ -8158,7 +8280,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/ui@0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
+  /@polar-sh/ui@0.1.2(@types/react@19.1.17)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
     resolution: {integrity: sha512-YTmMB2lr+PplMTDZnTs0Crgu0KNBKyQcSX4N0FYXSlo1Q6e9IKs4hwzEcqNUv3eHS4BxGO1SvxxNjuSK+il49Q==}
     peerDependencies:
       react: 19.1.0
@@ -8203,7 +8325,7 @@ packages:
       - redux
     dev: false
 
-  /@polar-sh/ui@0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1):
+  /@polar-sh/ui@0.1.2(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0):
     resolution: {integrity: sha512-YTmMB2lr+PplMTDZnTs0Crgu0KNBKyQcSX4N0FYXSlo1Q6e9IKs4hwzEcqNUv3eHS4BxGO1SvxxNjuSK+il49Q==}
     peerDependencies:
       react: 19.1.0
@@ -16720,6 +16842,102 @@ packages:
       kysely: 0.28.5
     dev: false
 
+  /drizzle-orm@0.45.1(@libsql/client@0.17.4)(bun-types@1.3.11):
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      '@libsql/client': 0.17.4
+      bun-types: 1.3.11
+    dev: false
+
   /drizzle-orm@0.45.1(expo-sqlite@16.0.10)(kysely@0.28.5):
     resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
     peerDependencies:
@@ -20658,6 +20876,25 @@ packages:
       '@libsql/linux-x64-gnu': 0.4.1
       '@libsql/linux-x64-musl': 0.4.1
       '@libsql/win32-x64-msvc': 0.4.1
+    dev: false
+
+  /libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
     dev: false
 
   /lighthouse-logger@1.4.2:


### PR DESCRIPTION
## What

Adds a `bahar grade` command and a couple of small CLI conveniences.

### `bahar grade <card-id> <again|hard|good|easy>`
Records a spaced-repetition review from the CLI:
- Runs the real FSRS scheduler (`@bahar/fsrs`) — the same algorithm web/mobile use.
- Writes the updated flashcard row and the daily streak (`user_stats`) to the user's personal Turso DB.
- Posts a review-log entry to `POST /stats/revlogs` (fire-and-forget, like mobile).

This gives agents/users a safe way to grade cards. Hand-writing FSRS fields via raw SQL desyncs the schedule, so the CLI owns this write.

### `bahar version` / `--version` / `-v` and `bahar help`
`@bunli/core` already handled `--help`/`-h`/no-args; this adds the missing `version` command + flag and a `help` alias.

## Notes
- **DB connection**: uses `@libsql/client/web` (fetch-based, remote-only — no embedded replica, no sync). Chosen over native `@libsql/client` and the new `@tursodatabase/*` SDK (embedded/native/beta) so the CLI stays native-free and still compiles into the single-file release binary. Verified: `bun build --compile` produces a working binary.
- **Streak logic is duplicated**: `recordReview` (incl. the "cards due in the gap" forgiveness check) is copied from mobile. It now lives in web, mobile, and CLI. **BAH-153** tracks extracting it into a shared package.
- **Tests**: `streak.test.ts` implements the insert branch; the remaining branches are boilerplate + pseudocode per the repo's test convention.
- Bundled `bahar-data-access` skill updated: grading documented as the only supported review path; supported/unsupported action list added.

## Verification
- typecheck, biome, `bun test` all pass; single-file binary compiles and runs (`grade help`, `version`).
- **Not yet run end-to-end against a live logged-in DB** (the actual remote write + revlog POST) — needs a real login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to grade flashcards from the terminal.
  * Added a version command to quickly display the CLI version.
  * Improved command-line help handling for a smoother experience.

* **Bug Fixes**
  * Review streaks and scheduling are now updated more consistently after grading.
  * Added safer handling for remote sync steps so grading still completes if logging fails.

* **Documentation**
  * Expanded CLI guidance with clearer rules for allowed review and deck actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->