### PR TITLE
fix(cli): surface actionable errors for non-JSON backend responses

### DIFF
--- a/apps/cli/src/commands/db-info.ts
+++ b/apps/cli/src/commands/db-info.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from "@bunli/core";
 import { API_URL } from "../lib/config";
 import { loadCredentials } from "../lib/credentials";
+import { readJsonResponse } from "../lib/http";
 
 export const dbInfoCommand = defineCommand({
   name: "db-info",
@@ -19,14 +20,17 @@ export const dbInfoCommand = defineCommand({
       headers: { "x-api-key": credentials.token },
     });
 
-    if (!response.ok) {
+    try {
+      const info = await readJsonResponse<unknown>({
+        response,
+        context: "Fetching database info",
+      });
+      console.log(JSON.stringify(info, null, 2));
+    } catch (error) {
       console.error(
-        colors.red(`Failed to fetch database info (${response.status}).`)
+        colors.red(error instanceof Error ? error.message : String(error))
       );
       process.exitCode = 1;
-      return;
     }
-
-    console.log(JSON.stringify(await response.json(), null, 2));
   },
 });

--- a/apps/cli/src/lib/db.ts
+++ b/apps/cli/src/lib/db.ts
@@ -2,6 +2,7 @@ import * as schema from "@bahar/drizzle-user-db-schemas";
 import { type Client, createClient } from "@libsql/client/web";
 import { drizzle } from "drizzle-orm/libsql/web";
 import { API_URL } from "./config";
+import { readJsonResponse } from "./http";
 
 export type UserDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -24,11 +25,10 @@ export const connectUserDb = async (
     headers: { "x-api-key": token },
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch database info (${response.status}).`);
-  }
-
-  const info = (await response.json()) as UserDatabaseInfo;
+  const info = await readJsonResponse<UserDatabaseInfo>({
+    response,
+    context: "Fetching database info",
+  });
 
   const client = createClient({
     url: `libsql://${info.hostname}`,

--- a/apps/cli/src/lib/http.test.ts
+++ b/apps/cli/src/lib/http.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { HttpResponseError, readJsonResponse } from "./http";
+
+const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+
+describe("readJsonResponse", () => {
+  test("parses a JSON body on a 2xx response", async () => {
+    const result = await readJsonResponse<{ hostname: string }>({
+      response: jsonResponse({ hostname: "db.example.com" }),
+      context: "Fetching database info",
+    });
+
+    expect(result).toEqual({ hostname: "db.example.com" });
+  });
+
+  test("throws an informative error for a non-JSON 2xx body", async () => {
+    const response = new Response("<html><body>maintenance</body></html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    });
+
+    const promise = readJsonResponse({
+      response,
+      context: "Fetching database info",
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(HttpResponseError);
+    await expect(promise).rejects.toThrow(/non-JSON response/);
+    await expect(promise).rejects.toThrow(/content-type text\/html/);
+    // The opaque Bun default must not leak through.
+    await expect(promise).rejects.not.toThrow(/^Failed to parse JSON$/);
+  });
+
+  test("includes status and a body snippet for a non-2xx response", async () => {
+    const response = new Response("Internal Server Error", {
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const promise = readJsonResponse({
+      response,
+      context: "Fetching database info",
+    });
+
+    await expect(promise).rejects.toThrow(/500/);
+    await expect(promise).rejects.toThrow(/Internal Server Error/);
+  });
+
+  test("adds a rate-limit hint for a 429", async () => {
+    const response = new Response("Too Many Requests", { status: 429 });
+
+    const promise = readJsonResponse({
+      response,
+      context: "Fetching database info",
+    });
+
+    await expect(promise).rejects.toThrow(/rate limiting|try again/i);
+  });
+
+  test("exposes the status on the thrown error", async () => {
+    const response = new Response("nope", { status: 503 });
+
+    try {
+      await readJsonResponse({ response, context: "Fetching database info" });
+      throw new Error("expected readJsonResponse to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpResponseError);
+      expect((error as HttpResponseError).status).toBe(503);
+    }
+  });
+});

--- a/apps/cli/src/lib/http.ts
+++ b/apps/cli/src/lib/http.ts
@@ -1,0 +1,77 @@
+/**
+ * Error carrying the HTTP status alongside a human-readable message, thrown by
+ * {@link readJsonResponse} when a backend response is unusable.
+ */
+export class HttpResponseError extends Error {
+  readonly status: number;
+
+  constructor({ message, status }: { message: string; status: number }) {
+    super(message);
+    this.name = "HttpResponseError";
+    this.status = status;
+  }
+}
+
+const SNIPPET_LENGTH = 300;
+
+const bodySnippet = (body: string): string =>
+  body.trim().replace(/\s+/g, " ").slice(0, SNIPPET_LENGTH);
+
+const looksRateLimited = ({
+  status,
+  body,
+}: {
+  status: number;
+  body: string;
+}): boolean =>
+  status === 429 ||
+  status === 503 ||
+  /rate limit|too many requests|try again/i.test(body);
+
+/**
+ * Reads a fetch `Response` as JSON, turning the two failure modes that
+ * otherwise surface as an opaque `Error: Failed to parse JSON` into actionable
+ * messages:
+ *
+ * - a non-2xx status, and
+ * - a 2xx status whose body is not JSON (e.g. an HTML proxy/CDN interstitial or
+ *   maintenance page that slips past a plain `response.ok` check).
+ *
+ * The body is read exactly once, so callers must not read it themselves.
+ */
+export const readJsonResponse = async <T>({
+  response,
+  context,
+}: {
+  response: Response;
+  context: string;
+}): Promise<T> => {
+  const body = await response.text();
+
+  if (!response.ok) {
+    const hint = looksRateLimited({ status: response.status, body })
+      ? " The server is rate limiting or temporarily unavailable — wait a moment and try again."
+      : "";
+    throw new HttpResponseError({
+      message: `${context} failed (${response.status} ${response.statusText}).${hint}${
+        body ? ` Response: ${bodySnippet(body)}` : ""
+      }`,
+      status: response.status,
+    });
+  }
+
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    const contentType = response.headers.get("content-type") ?? "unknown";
+    const hint = looksRateLimited({ status: response.status, body })
+      ? " This looks like a rate-limit or maintenance page — wait a moment and try again."
+      : " The server returned a non-JSON response, which usually means a proxy/CDN error or maintenance page.";
+    throw new HttpResponseError({
+      message: `${context} returned a non-JSON response (status ${response.status}, content-type ${contentType}).${hint}${
+        body ? ` Response: ${bodySnippet(body)}` : ""
+      }`,
+      status: response.status,
+    });
+  }
+};


### PR DESCRIPTION
## Problem

`bahar db-info` and `bahar grade` both fail with a bare, opaque:

```
Error: Failed to parse JSON
```

whenever the backend returns a body that isn't JSON. Both commands call
`response.json()` directly; when the response body can't be parsed, Bun throws
`SyntaxError: Failed to parse JSON`, which `@bunli/core` prints verbatim. The
user gets no status code, no body, and no signal that it's a transient server
issue they should just retry.

The existing `if (!response.ok)` guards do **not** catch this: the failure was
observed on a **2xx** response whose body was an HTML interstitial / maintenance
page (e.g. a proxy or CDN page served with status 200), which sails past the
`.ok` check and only blows up at `.json()`.

## Fix

Add `readJsonResponse` (`apps/cli/src/lib/http.ts`), a small shared helper that
reads the response body once and turns both failure modes into an
`HttpResponseError` with an actionable message:

- **non-2xx** → status, status text, and a trimmed body snippet;
- **2xx with a non-JSON body** → status, `content-type`, and a body snippet.

Both add a "wait a moment and try again" hint when the response looks
rate-limited (429/503, or a body matching `rate limit` / `too many requests` /
`try again`).

Routed both call sites through it: `db-info` (`commands/db-info.ts`) and
`connectUserDb` (`lib/db.ts`, used by `grade`).

### Before / after

```
# before
Error: Failed to parse JSON

# after (200 HTML body)
Fetching database info returned a non-JSON response (status 200, content-type text/html). This looks like a rate-limit or maintenance page — wait a moment and try again. Response: <html>...

# after (429)
Error: Fetching database info failed (429 Too Many Requests). The server is rate limiting or temporarily unavailable — wait a moment and try again. Response: Too Many Requests
```

## Testing

- Unit tests for `readJsonResponse` (`apps/cli/src/lib/http.test.ts`): valid
  JSON, non-JSON 2xx body, non-2xx with snippet, 429 hint, and status exposed on
  the error. `bun test` green; `tsc --noEmit` clean.
- Verified end-to-end by running `bahar db-info` and `bahar grade` against a
  local mock backend returning a 200 HTML body and a 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved database info handling in the CLI with clearer, more consistent error messages.
  * Added support for better reporting when API responses are invalid, non-JSON, or rate-limited.

* **Bug Fixes**
  * Reduced failures caused by parsing response data twice.
  * Exit codes now correctly reflect database info retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->