### PR TITLE
feat(cli): grade many flashcards in one batched command

### DIFF
--- a/apps/cli/src/commands/grade.ts
+++ b/apps/cli/src/commands/grade.ts
@@ -1,85 +1,56 @@
-import {
-  flashcards,
-  type SelectFlashcard,
-} from "@bahar/drizzle-user-db-schemas";
-import { createScheduler, getSchedulingOptions } from "@bahar/fsrs";
 import { defineCommand } from "@bunli/core";
-import { eq } from "drizzle-orm";
-import { type Grade, Rating } from "ts-fsrs";
+import { applyGrades } from "../lib/apply-grades";
 import { loadCredentials } from "../lib/credentials";
 import { connectUserDb } from "../lib/db";
-import { postRevlog } from "../lib/revlog";
-import { recordReview } from "../lib/streak";
-
-const GRADE_BY_LABEL: Record<string, Grade> = {
-  again: Rating.Again,
-  hard: Rating.Hard,
-  good: Rating.Good,
-  easy: Rating.Easy,
-};
-
-const GRADE_LABELS = Object.keys(GRADE_BY_LABEL).join(" | ");
+import { GRADE_LABELS } from "../lib/grade";
+import { type GradeItem, parseGradeInput } from "../lib/grade-input";
+import { postRevlogsBatch } from "../lib/revlog";
 
 const printHelp = () => {
-  console.log(`Grade a flashcard, running the real FSRS scheduler.
+  console.log(`Grade one or more flashcards, running the real FSRS scheduler.
 
 Usage:
-  bahar grade <card-id> <grade>    Grade the card and persist: updates the
-                                   flashcard, the streak, and the review log.
-  bahar grade help                 Show this help.
+  bahar grade <id> <grade>            Grade a single card.
+  bahar grade <id...> <grade>         Grade many cards with the same grade
+                                      (the grade is always the last argument).
+  bahar grade < cards.json            Grade with per-card grades from stdin,
+                                      a JSON array: [{"id": "...", "grade": "..."}]
+  bahar grade help                    Show this help.
 
   <grade>   one of: ${GRADE_LABELS}
 
-Find a card's id by querying the user's database directly (see the
-bahar-data-access skill). Never hand-write FSRS fields — always grade here.`);
+However many cards are graded, this opens one connection, persists every
+flashcard update in a single batch, advances the streak once, and posts all
+review logs in one request. Find a card's id by querying the user's database
+directly (see the bahar-data-access skill). Never hand-write FSRS fields —
+always grade here.`);
 };
-
-/**
- * Builds the flashcard columns to persist from a scheduled FSRS card.
- * Matches the update the web/mobile apps write on a review.
- */
-const toFlashcardUpdate = (
-  card: ReturnType<typeof getSchedulingOptions>[Grade]["card"]
-) => ({
-  due: card.due.toISOString(),
-  due_timestamp_ms: card.due.getTime(),
-  last_review: card.last_review?.toISOString() ?? null,
-  last_review_timestamp_ms: card.last_review?.getTime() ?? null,
-  state: card.state,
-  stability: card.stability,
-  difficulty: card.difficulty,
-  reps: card.reps,
-  lapses: card.lapses,
-  elapsed_days: card.elapsed_days,
-  scheduled_days: card.scheduled_days,
-  learning_steps: card.learning_steps,
-});
 
 export const gradeCommand = defineCommand({
   name: "grade",
-  description: "Grade a flashcard (preview intervals, or grade and persist)",
+  description: "Grade one or more flashcards (from args or stdin)",
   handler: async ({ positional, colors }) => {
-    const [cardId, gradeArg] = positional as string[];
+    const args = positional as string[];
 
-    if (!cardId || cardId === "help") {
+    if (args[0] === "help") {
       printHelp();
       return;
     }
 
-    if (!gradeArg) {
+    let items: GradeItem[];
+    try {
+      const stdin = process.stdin.isTTY ? null : await Bun.stdin.text();
+      items = parseGradeInput({ positional: args, stdin });
+    } catch (error) {
       console.error(
-        colors.red(`A grade is required. Use one of: ${GRADE_LABELS}.`)
+        colors.red(error instanceof Error ? error.message : String(error))
       );
       process.exitCode = 1;
       return;
     }
 
-    const grade = GRADE_BY_LABEL[gradeArg.toLowerCase()];
-    if (grade === undefined) {
-      console.error(
-        colors.red(`Invalid grade "${gradeArg}". Use one of: ${GRADE_LABELS}.`)
-      );
-      process.exitCode = 1;
+    if (items.length === 0) {
+      printHelp();
       return;
     }
 
@@ -93,47 +64,38 @@ export const gradeCommand = defineCommand({
     const { db, client } = await connectUserDb(credentials.token);
 
     try {
-      const [card] = (await db
-        .select()
-        .from(flashcards)
-        .where(eq(flashcards.id, cardId))
-        .limit(1)) as SelectFlashcard[];
+      const { results, missing, revlogEntries } = await applyGrades({
+        db,
+        items,
+      });
 
-      if (!card) {
-        console.error(colors.red(`No flashcard found with id "${cardId}".`));
-        process.exitCode = 1;
-        return;
+      if (revlogEntries.length > 0) {
+        // Fire-and-forget like the app — a failed revlog must not fail grades.
+        await postRevlogsBatch({
+          token: credentials.token,
+          entries: revlogEntries,
+        }).catch((err) => {
+          console.warn(`Failed to post review logs: ${err}`);
+        });
       }
 
-      const scheduler = createScheduler();
-      const now = new Date();
-      const { card: scheduled, log } = getSchedulingOptions(
-        scheduler,
-        card,
-        now
-      )[grade];
-      const updates = toFlashcardUpdate(scheduled);
-
-      await db.update(flashcards).set(updates).where(eq(flashcards.id, cardId));
-      await recordReview(db);
-
-      // Fire-and-forget like the app — a failed revlog must not fail the grade.
-      await postRevlog({
-        token: credentials.token,
-        log,
-        direction: card.direction,
-        dictionaryEntryId: card.dictionary_entry_id,
-      }).catch((err) => {
-        console.warn(`Failed to post revlog: ${err}`);
-      });
+      for (const id of missing) {
+        console.warn(
+          colors.yellow(`Skipped: no flashcard found with id "${id}".`)
+        );
+      }
 
       console.log(
         JSON.stringify(
-          { id: cardId, grade: gradeArg.toLowerCase(), ...updates },
+          { graded: results.length, skipped: missing.length, results, missing },
           null,
           2
         )
       );
+
+      if (missing.length > 0) {
+        process.exitCode = 1;
+      }
     } finally {
       client.close();
     }

--- a/apps/cli/src/lib/apply-grades.test.ts
+++ b/apps/cli/src/lib/apply-grades.test.ts
@@ -1,0 +1,162 @@
+import { createClient } from "@libsql/client";
+import * as schema from "@bahar/drizzle-user-db-schemas";
+import { flashcards, userStats } from "@bahar/drizzle-user-db-schemas";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/libsql";
+import { eq } from "drizzle-orm";
+import { applyGrades } from "./apply-grades";
+import type { UserDb } from "./db";
+import { parseGradeInput } from "./grade-input";
+
+const MIGRATIONS_DIR = new URL(
+  "../../../../packages/drizzle-user-db-schemas/drizzle/",
+  import.meta.url
+);
+const MIGRATION_FILES = [
+  "0000_complete_changeling.sql",
+  "0001_even_kitty_pryde.sql",
+  "0002_watery_blink.sql",
+  "0003_tearful_marten_broadcloak.sql",
+];
+
+const buildDb = async (): Promise<{
+  db: UserDb;
+  raw: ReturnType<typeof createClient>;
+}> => {
+  const raw = createClient({ url: ":memory:" });
+
+  for (const file of MIGRATION_FILES) {
+    const sql = await Bun.file(new URL(file, MIGRATIONS_DIR)).text();
+    const statements = sql
+      .split("--> statement-breakpoint")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const statement of statements) {
+      await raw.execute(statement);
+    }
+  }
+
+  const db = drizzle(raw, { schema }) as unknown as UserDb;
+  return { db, raw };
+};
+
+const seedCard = async (
+  raw: ReturnType<typeof createClient>,
+  id: string
+): Promise<void> => {
+  // Each card needs its own dictionary entry: flashcards are unique on
+  // (dictionary_entry_id, direction), and there is a FK to dictionary_entries.
+  const entryId = `entry-${id}`;
+  await raw.execute({
+    sql: "INSERT INTO dictionary_entries (id, word, translation, type) VALUES (?, ?, ?, ?)",
+    args: [entryId, "نور", "light", "ism"],
+  });
+
+  // A card in the review state, due in the past.
+  const past = Date.now() - 5 * 24 * 60 * 60 * 1000;
+  await raw.execute({
+    sql: `INSERT INTO flashcards
+      (id, dictionary_entry_id, due, due_timestamp_ms, direction, is_hidden,
+       state, reps, lapses, stability, difficulty, scheduled_days, elapsed_days, learning_steps)
+      VALUES (?, ?, ?, ?, 'forward', 0, 2, 3, 0, 10.5, 6.0, 5, 5, 0)`,
+    args: [id, entryId, new Date(past).toISOString(), past],
+  });
+};
+
+describe("applyGrades", () => {
+  let db: UserDb;
+  let raw: ReturnType<typeof createClient>;
+
+  beforeEach(async () => {
+    ({ db, raw } = await buildDb());
+  });
+
+  test("grades many cards in one batch and pushes their due dates out", async () => {
+    await seedCard(raw, "card-a");
+    await seedCard(raw, "card-b");
+
+    const items = parseGradeInput({
+      positional: ["card-a", "card-b", "good"],
+      stdin: null,
+    });
+
+    const now = new Date();
+    const { results, missing, revlogEntries } = await applyGrades({
+      db,
+      items,
+      now,
+    });
+
+    expect(missing).toEqual([]);
+    expect(results.map((r) => r.id).sort()).toEqual(["card-a", "card-b"]);
+    expect(results.every((r) => r.grade === "good")).toBe(true);
+    expect(revlogEntries).toHaveLength(2);
+
+    // Both rows were actually written, with a future due and an extra rep.
+    const rows = await db.select().from(flashcards);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.due_timestamp_ms).toBeGreaterThan(now.getTime());
+      expect(row.reps).toBe(4);
+      expect(row.last_review_timestamp_ms).not.toBeNull();
+    }
+  });
+
+  test("reports missing card ids and still grades the found ones", async () => {
+    await seedCard(raw, "card-a");
+
+    const items = parseGradeInput({
+      positional: ["card-a", "does-not-exist", "hard"],
+      stdin: null,
+    });
+
+    const { results, missing } = await applyGrades({ db, items });
+
+    expect(results.map((r) => r.id)).toEqual(["card-a"]);
+    expect(missing).toEqual(["does-not-exist"]);
+  });
+
+  test("applies mixed grades from a stdin-style payload", async () => {
+    await seedCard(raw, "card-a");
+    await seedCard(raw, "card-b");
+
+    const items = parseGradeInput({
+      positional: [],
+      stdin: JSON.stringify([
+        { id: "card-a", grade: "again" },
+        { id: "card-b", grade: "easy" },
+      ]),
+    });
+
+    const { results } = await applyGrades({ db, items });
+
+    const byId = Object.fromEntries(results.map((r) => [r.id, r.grade]));
+    expect(byId).toEqual({ "card-a": "again", "card-b": "easy" });
+
+    // "again" should schedule sooner than "easy".
+    const [a] = await db
+      .select()
+      .from(flashcards)
+      .where(eq(flashcards.id, "card-a"));
+    const [b] = await db
+      .select()
+      .from(flashcards)
+      .where(eq(flashcards.id, "card-b"));
+    expect(a.due_timestamp_ms).toBeLessThan(b.due_timestamp_ms as number);
+  });
+
+  test("advances the streak exactly once for a batch", async () => {
+    await seedCard(raw, "card-a");
+    await seedCard(raw, "card-b");
+
+    const items = parseGradeInput({
+      positional: ["card-a", "card-b", "good"],
+      stdin: null,
+    });
+    await applyGrades({ db, items });
+
+    const stats = await db.select().from(userStats);
+    expect(stats).toHaveLength(1);
+    expect(stats[0].streak_count).toBe(1);
+  });
+});

--- a/apps/cli/src/lib/apply-grades.ts
+++ b/apps/cli/src/lib/apply-grades.ts
@@ -1,0 +1,81 @@
+import {
+  flashcards,
+  type SelectFlashcard,
+} from "@bahar/drizzle-user-db-schemas";
+import { createScheduler } from "@bahar/fsrs";
+import { eq, inArray } from "drizzle-orm";
+import type { UserDb } from "./db";
+import { scheduleGrade } from "./grade";
+import type { GradeItem } from "./grade-input";
+import { recordReview } from "./streak";
+import type { RevlogInput } from "./revlog";
+
+export type GradeResult = { id: string; grade: string; due: string };
+
+export type ApplyGradesResult = {
+  results: GradeResult[];
+  missing: string[];
+  revlogEntries: RevlogInput[];
+};
+
+/**
+ * Grades every item against the database in one pass: fetches all target cards
+ * in a single query, runs the FSRS scheduler per card, persists all flashcard
+ * updates in one atomic batch, and advances the streak once.
+ *
+ * Ids with no matching flashcard are returned in `missing` and skipped. Review
+ * logs are returned (not posted) so the caller owns the network call.
+ */
+export const applyGrades = async ({
+  db,
+  items,
+  now = new Date(),
+}: {
+  db: UserDb;
+  items: GradeItem[];
+  now?: Date;
+}): Promise<ApplyGradesResult> => {
+  const ids = items.map((item) => item.id);
+  const cards = (await db
+    .select()
+    .from(flashcards)
+    .where(inArray(flashcards.id, ids))) as SelectFlashcard[];
+
+  const cardById = new Map(cards.map((card) => [card.id, card]));
+  const missing = ids.filter((id) => !cardById.has(id));
+
+  const scheduler = createScheduler();
+  const updateStatements = [];
+  const revlogEntries: RevlogInput[] = [];
+  const results: GradeResult[] = [];
+
+  for (const { id, gradeLabel, grade } of items) {
+    const card = cardById.get(id);
+    if (!card) continue;
+
+    const { updates, log } = scheduleGrade({ scheduler, card, grade, now });
+
+    updateStatements.push(
+      db.update(flashcards).set(updates).where(eq(flashcards.id, id))
+    );
+    revlogEntries.push({
+      log,
+      direction: card.direction,
+      dictionaryEntryId: card.dictionary_entry_id,
+    });
+    results.push({ id, grade: gradeLabel, due: updates.due });
+  }
+
+  if (updateStatements.length > 0) {
+    // One atomic round-trip for every flashcard update.
+    await db.batch(
+      updateStatements as [
+        (typeof updateStatements)[number],
+        ...(typeof updateStatements)[number][],
+      ]
+    );
+    await recordReview(db);
+  }
+
+  return { results, missing, revlogEntries };
+};

--- a/apps/cli/src/lib/grade-input.test.ts
+++ b/apps/cli/src/lib/grade-input.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { Rating } from "ts-fsrs";
+import { parseGradeInput } from "./grade-input";
+
+describe("parseGradeInput", () => {
+  test("positional: single card, grade last (backward compatible)", () => {
+    const items = parseGradeInput({
+      positional: ["card-a", "good"],
+      stdin: null,
+    });
+    expect(items).toEqual([
+      { id: "card-a", gradeLabel: "good", grade: Rating.Good },
+    ]);
+  });
+
+  test("positional: many cards, same grade (grade last)", () => {
+    const items = parseGradeInput({
+      positional: ["a", "b", "c", "hard"],
+      stdin: null,
+    });
+
+    expect(items).toEqual([
+      { id: "a", gradeLabel: "hard", grade: Rating.Hard },
+      { id: "b", gradeLabel: "hard", grade: Rating.Hard },
+      { id: "c", gradeLabel: "hard", grade: Rating.Hard },
+    ]);
+  });
+
+  test("positional: grade label is case-insensitive", () => {
+    const [item] = parseGradeInput({ positional: ["a", "GOOD"], stdin: null });
+    expect(item).toEqual({ id: "a", gradeLabel: "good", grade: Rating.Good });
+  });
+
+  test("positional: rejects an unknown grade", () => {
+    expect(() =>
+      parseGradeInput({ positional: ["a", "meh"], stdin: null })
+    ).toThrow(/Invalid grade "meh"/);
+  });
+
+  test("positional: requires at least one id (grade only)", () => {
+    expect(() =>
+      parseGradeInput({ positional: ["hard"], stdin: null })
+    ).toThrow(/at least one card id/);
+  });
+
+  test("stdin: parses a JSON array of mixed grades", () => {
+    const stdin = JSON.stringify([
+      { id: "a", grade: "again" },
+      { id: "b", grade: "easy" },
+    ]);
+    const items = parseGradeInput({ positional: [], stdin });
+
+    expect(items).toEqual([
+      { id: "a", gradeLabel: "again", grade: Rating.Again },
+      { id: "b", gradeLabel: "easy", grade: Rating.Easy },
+    ]);
+  });
+
+  test("positional takes precedence over stdin", () => {
+    const stdin = JSON.stringify([{ id: "z", grade: "easy" }]);
+    const items = parseGradeInput({ positional: ["a", "hard"], stdin });
+    expect(items).toEqual([
+      { id: "a", gradeLabel: "hard", grade: Rating.Hard },
+    ]);
+  });
+
+  test("returns empty when no positional args and no stdin", () => {
+    expect(parseGradeInput({ positional: [], stdin: null })).toEqual([]);
+    expect(parseGradeInput({ positional: [], stdin: "   " })).toEqual([]);
+  });
+
+  test("stdin: rejects non-array JSON", () => {
+    expect(() =>
+      parseGradeInput({ positional: [], stdin: '{"id":"a","grade":"good"}' })
+    ).toThrow(/array/);
+  });
+
+  test("stdin: rejects malformed JSON", () => {
+    expect(() =>
+      parseGradeInput({ positional: [], stdin: "not json" })
+    ).toThrow(/parse stdin as JSON/);
+  });
+
+  test("stdin: rejects an entry missing id/grade", () => {
+    expect(() =>
+      parseGradeInput({ positional: [], stdin: JSON.stringify([{ id: "a" }]) })
+    ).toThrow(/index 0/);
+  });
+
+  test("rejects duplicate ids", () => {
+    expect(() =>
+      parseGradeInput({ positional: ["a", "a", "hard"], stdin: null })
+    ).toThrow(/Duplicate card id "a"/);
+  });
+});

--- a/apps/cli/src/lib/grade-input.ts
+++ b/apps/cli/src/lib/grade-input.ts
@@ -1,0 +1,98 @@
+import type { Grade } from "ts-fsrs";
+import { GRADE_LABELS, parseGradeLabel } from "./grade";
+
+export type GradeItem = {
+  id: string;
+  gradeLabel: string;
+  grade: Grade;
+};
+
+const resolve = ({ id, gradeLabel }: { id: string; gradeLabel: string }) => {
+  const grade = parseGradeLabel(gradeLabel);
+  if (grade === undefined) {
+    throw new Error(
+      `Invalid grade "${gradeLabel}" for card "${id}". Use one of: ${GRADE_LABELS}.`
+    );
+  }
+  return { id, gradeLabel: gradeLabel.toLowerCase(), grade };
+};
+
+const parseStdin = (stdin: string): { id: string; gradeLabel: string }[] => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdin);
+  } catch {
+    throw new Error(
+      'Could not parse stdin as JSON. Expected an array like [{"id": "...", "grade": "good"}].'
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      'Expected a JSON array of {"id", "grade"} objects on stdin.'
+    );
+  }
+
+  return parsed.map((entry, index) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as Record<string, unknown>).id !== "string" ||
+      typeof (entry as Record<string, unknown>).grade !== "string"
+    ) {
+      throw new Error(
+        `Entry at index ${index} must be an object with string "id" and "grade" fields.`
+      );
+    }
+    const { id, grade } = entry as { id: string; grade: string };
+    return { id, gradeLabel: grade };
+  });
+};
+
+/**
+ * Resolves the cards-to-grade for `grade` from either:
+ *
+ * - positional args `<id...> <grade>` — the grade is always the last argument,
+ *   so `grade <id> <grade>` (one card) and `grade <id1> <id2> <grade>` (many,
+ *   same grade) share one shape, or
+ * - a JSON array `[{"id", "grade"}]` piped on stdin — for per-card grades.
+ *
+ * Positional args take precedence when present. Throws on an unknown grade,
+ * a malformed stdin payload, or a duplicate card id.
+ */
+export const parseGradeInput = ({
+  positional,
+  stdin,
+}: {
+  positional: string[];
+  stdin: string | null;
+}): GradeItem[] => {
+  let raw: { id: string; gradeLabel: string }[];
+
+  if (positional.length > 0) {
+    const gradeLabel = positional[positional.length - 1];
+    const ids = positional.slice(0, -1);
+    if (ids.length === 0) {
+      throw new Error(
+        `Provide at least one card id: bahar grade <id...> <grade>. Grades: ${GRADE_LABELS}.`
+      );
+    }
+    raw = ids.map((id) => ({ id, gradeLabel }));
+  } else if (stdin && stdin.trim().length > 0) {
+    raw = parseStdin(stdin);
+  } else {
+    return [];
+  }
+
+  const items = raw.map(resolve);
+
+  const seen = new Set<string>();
+  for (const { id } of items) {
+    if (seen.has(id)) {
+      throw new Error(`Duplicate card id "${id}" in batch.`);
+    }
+    seen.add(id);
+  }
+
+  return items;
+};

--- a/apps/cli/src/lib/grade.ts
+++ b/apps/cli/src/lib/grade.ts
@@ -1,0 +1,60 @@
+import type { SelectFlashcard } from "@bahar/drizzle-user-db-schemas";
+import { type createScheduler, getSchedulingOptions } from "@bahar/fsrs";
+import { type Grade, Rating, type ReviewLog } from "ts-fsrs";
+
+export const GRADE_BY_LABEL: Record<string, Grade> = {
+  again: Rating.Again,
+  hard: Rating.Hard,
+  good: Rating.Good,
+  easy: Rating.Easy,
+};
+
+export const GRADE_LABELS = Object.keys(GRADE_BY_LABEL).join(" | ");
+
+/** Resolves a user-supplied grade label to an FSRS grade, or `undefined`. */
+export const parseGradeLabel = (raw: string): Grade | undefined =>
+  GRADE_BY_LABEL[raw.toLowerCase()];
+
+/**
+ * Flashcard columns persisted on a review. Matches the update the web/mobile
+ * apps write, so a CLI grade is indistinguishable from an in-app one.
+ */
+export const toFlashcardUpdate = (
+  card: ReturnType<typeof getSchedulingOptions>[Grade]["card"]
+) => ({
+  due: card.due.toISOString(),
+  due_timestamp_ms: card.due.getTime(),
+  last_review: card.last_review?.toISOString() ?? null,
+  last_review_timestamp_ms: card.last_review?.getTime() ?? null,
+  state: card.state,
+  stability: card.stability,
+  difficulty: card.difficulty,
+  reps: card.reps,
+  lapses: card.lapses,
+  elapsed_days: card.elapsed_days,
+  scheduled_days: card.scheduled_days,
+  learning_steps: card.learning_steps,
+});
+
+export type FlashcardUpdate = ReturnType<typeof toFlashcardUpdate>;
+
+/**
+ * Runs the FSRS scheduler for a single card + grade, returning both the columns
+ * to persist and the review log to record.
+ */
+export const scheduleGrade = ({
+  scheduler,
+  card,
+  grade,
+  now,
+}: {
+  scheduler: ReturnType<typeof createScheduler>;
+  card: SelectFlashcard;
+  grade: Grade;
+  now: Date;
+}): { updates: FlashcardUpdate; log: ReviewLog } => {
+  const { card: scheduled, log } = getSchedulingOptions(scheduler, card, now)[
+    grade
+  ];
+  return { updates: toFlashcardUpdate(scheduled), log };
+};

--- a/apps/cli/src/lib/revlog.ts
+++ b/apps/cli/src/lib/revlog.ts
@@ -1,6 +1,7 @@
 import type { FlashcardDirection } from "@bahar/drizzle-user-db-schemas";
 import { type Grade, Rating, type ReviewLog } from "ts-fsrs";
 import { API_URL } from "./config";
+import { readJsonResponse } from "./http";
 
 const RATING_TO_LABEL: Record<Grade, "again" | "hard" | "good" | "easy"> = {
   [Rating.Again]: "again",
@@ -9,34 +10,44 @@ const RATING_TO_LABEL: Record<Grade, "again" | "hard" | "good" | "easy"> = {
   [Rating.Easy]: "easy",
 };
 
-/**
- * Posts a review-log entry to the server-side stats table (central API DB,
- * keyed by user). Mirrors the mobile app's fire-and-forget revlog post.
- */
-export const postRevlog = async ({
-  token,
-  log,
-  direction,
-  dictionaryEntryId,
-}: {
-  token: string;
+export type RevlogInput = {
   log: ReviewLog;
   direction: FlashcardDirection;
   dictionaryEntryId: string;
+};
+
+/** Serializes an FSRS review log into the server's revlog entry shape. */
+const toRevlogEntry = ({ log, direction, dictionaryEntryId }: RevlogInput) => ({
+  ...log,
+  due: log.due.toISOString(),
+  review: log.review.toISOString(),
+  rating: RATING_TO_LABEL[log.rating as Grade],
+  direction,
+  dictionary_entry_id: dictionaryEntryId,
+});
+
+/**
+ * Posts review-log entries in a single request via `/stats/revlogs/batch`,
+ * so grading N cards costs one round-trip rather than N. Mirrors the app's
+ * fire-and-forget revlog post.
+ */
+export const postRevlogsBatch = async ({
+  token,
+  entries,
+}: {
+  token: string;
+  entries: RevlogInput[];
 }): Promise<void> => {
-  await fetch(new URL("/stats/revlogs", API_URL), {
+  if (entries.length === 0) return;
+
+  const response = await fetch(new URL("/stats/revlogs/batch", API_URL), {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-api-key": token,
     },
-    body: JSON.stringify({
-      ...log,
-      due: log.due.toISOString(),
-      review: log.review.toISOString(),
-      rating: RATING_TO_LABEL[log.rating as Grade],
-      direction,
-      dictionary_entry_id: dictionaryEntryId,
-    }),
+    body: JSON.stringify({ entries: entries.map(toRevlogEntry) }),
   });
+
+  await readJsonResponse({ response, context: "Posting review logs" });
 };


### PR DESCRIPTION
## What

Extends `bahar grade` to grade one card, many cards, or a stdin payload — always through a single batched path. No new command; the existing `grade <id> <grade>` form is unchanged because the grade is always the **last** positional argument.

```
bahar grade <id> <grade>                            # single (unchanged)
bahar grade <id1> <id2> <id3> <grade>               # many, same grade
echo '[{"id":"..","grade":"good"}]' | bahar grade   # mixed grades via stdin
```

## Why

Previously `grade` handled one card per process, and every invocation opened its own backend connection to fetch DB credentials (`GET /databases/user`). Grading a backlog meant a loop of N processes hammering that endpoint, which trips rate limiting (the backend then returns non-JSON error pages — see the companion error-handling fix in cli-v1.1.1).

However many cards are graded, this now:
- opens **one** connection,
- fetches all target cards in one `inArray` query,
- runs the real FSRS scheduler per card,
- persists every flashcard update in one atomic `db.batch`,
- advances the streak **once**, and
- posts all review logs in one request via the existing `POST /stats/revlogs/batch` endpoint.

## Structure

- `lib/grade.ts` — shared FSRS scheduling + grade-label parsing (previously inline in the command).
- `lib/grade-input.ts` — resolves args/stdin into grade items (grade-last ordering, duplicate-id + unknown-grade validation).
- `lib/apply-grades.ts` — the DB work (fetch → schedule → `db.batch` → streak), extracted so it can be integration-tested.
- `commands/grade.ts` — thin: parse → connect → apply → post revlogs → print a JSON summary `{ graded, skipped, results, missing }`.
- `lib/revlog.ts` — adds `postRevlogsBatch`; drops the now-unused single-entry poster.

## Behavior change

Output is now always the batch summary JSON (including for a single card), and unknown ids are reported under `missing` with a non-zero exit code rather than aborting the whole run.

## Testing

- Unit tests for input parsing (backward-compat single form, many-same-grade, stdin mixed grades, precedence, validation, dedupe).
- Integration test runs `applyGrades` against a **local libsql** seeded from the real user-db migrations: verifies batched writes, mixed-grade scheduling order, missing-id handling, and that the streak advances exactly once per batch.
- `bun test` green (28 tests); `tsc --noEmit` clean. CLI smoke-tested for help and parse-error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)