### PR TITLE
fix(web): don't log out on transient get-session 429

### DIFF
--- a/apps/web/src/hooks/useLogout.ts
+++ b/apps/web/src/hooks/useLogout.ts
@@ -38,7 +38,7 @@ export const useLogout = () => {
     Sentry.setUser(null);
 
     resetOramaDb();
-    await resetDb();
+    await resetDb("logout");
   };
 
   return { logout };

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -7,6 +7,7 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 import type { auth } from "../../../api/src/auth";
+import { queryClient } from "./query";
 import { generateTraceId, TRACE_ID_HEADER } from "./utils";
 
 export const authClient = createAuthClient({
@@ -24,3 +25,40 @@ export const authClient = createAuthClient({
     },
   },
 });
+
+// Reuse a fetched session for as long as the server keeps its signed
+// session cookie cache valid (see SESSION_COOKIE_CACHE_EXPIRY_SECS in the API
+// auth config). Route `beforeLoad`s run on every navigation and nest three
+// deep, so without this each navigation fires several `/get-session` requests
+// and rapid navigation trips the endpoint's rate limit (429).
+const SESSION_STALE_TIME_MS = 1000 * 60 * 5;
+
+const sessionQueryOptions = {
+  queryKey: ["auth.session"],
+  queryFn: () => authClient.getSession(),
+  staleTime: SESSION_STALE_TIME_MS,
+} as const;
+
+// Derived from the (non-generic) queryFn rather than
+// `ReturnType<typeof authClient.getSession>`: `getSession` is generic and its
+// return type varies on the type param, so `ReturnType` collapses it to `any`.
+type SessionResult = Awaited<ReturnType<typeof sessionQueryOptions.queryFn>>;
+
+/**
+ * Fetches the current session, deduped across route `beforeLoad` calls and
+ * rapid navigation via Tanstack Query. Returns better-auth's
+ * `{ data, error }` shape untouched. The cache is cleared on logout via
+ * `queryClient.clear()` in `useLogout`.
+ */
+export const getCachedSession = (): Promise<SessionResult> =>
+  queryClient.ensureQueryData(sessionQueryOptions);
+
+/**
+ * True only for a *confirmed* logged-out response. better-auth returns a 200
+ * with `data: null` (and no error) when there's no session, or a 401. A 429
+ * rate-limit or a network failure returns `data: null` WITH a transient error
+ * -- those must NOT be treated as logged out, otherwise a redirect to the
+ * unauthorized layout calls `resetDb()` and closes the local db mid-read.
+ */
+export const isLoggedOut = ({ data, error }: SessionResult): boolean =>
+  !data && (!error || error.status === 401);

--- a/apps/web/src/lib/db/index.ts
+++ b/apps/web/src/lib/db/index.ts
@@ -93,7 +93,16 @@ export const ensureDb = async () => {
   return getDb();
 };
 
-export const resetDb = async () => {
+/**
+ * Why resetDb ran. `hadLiveDb: true` in the log means a live connection was
+ * closed -- the dangerous case, since it releases the OPFS SyncAccessHandle
+ * out from under any in-flight reads.
+ */
+type ResetDbCaller = "logout" | "unauthorized_redirect" | "delete_local_db";
+
+export const resetDb = async (caller: ResetDbCaller) => {
+  Sentry.logger.info("resetDb called", { caller, hadLiveDb: db != null });
+
   if (db) {
     await db.close();
     db = null;
@@ -113,7 +122,7 @@ export const resetDb = async () => {
  * the data will be in a worse state.
  */
 export const deleteLocalDatabase = async () => {
-  await resetDb();
+  await resetDb("delete_local_db");
 
   // Delete all OPFS files starting with our prefix
   const opfsRoot = await navigator.storage.getDirectory();
@@ -167,7 +176,10 @@ export const initDb = async () => {
 
   dbInitPromise = _initDbInternal();
   const result = await dbInitPromise;
-  if (!result.ok) dbInitPromise = null; // Allow retry on failure
+  if (!result.ok) {
+    dbInitPromise = null; // Allow retry on failure
+    Sentry.logger.warn("initDb failed", { outcome: result.error.type });
+  }
   return result;
 };
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,31 @@
 import { registerSW } from "virtual:pwa-register";
+import * as Sentry from "@sentry/react";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./globals.css";
 
 registerSW({ immediate: true });
+
+// The sync-wasm OPFS worker rejects with "Cannot read properties of undefined
+// (reading 'read')" (at readFileAtWorker/read_async) when its SyncAccessHandle
+// is released while a read is in flight. It surfaces as an uncaught promise
+// rejection rather than through a caught query path, so capture it explicitly
+// as a distinct, trace-correlated event instead of letting it be console noise.
+window.addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason;
+  const message = reason instanceof Error ? reason.message : String(reason);
+
+  const isOpfsWorkerRead =
+    message.includes("reading 'read'") || message.includes("readFileAtWorker");
+
+  if (isOpfsWorkerRead) {
+    Sentry.captureException(reason, {
+      fingerprint: ["opfs-worker-read-rejection"],
+      tags: { source: "opfs_worker" },
+    });
+  }
+});
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/web/src/routes/_authorized-layout/_app-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/_app-layout/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { DesktopNavigation } from "@/components/DesktopNavigation";
 import { MobileHeader } from "@/components/MobileHeader";
-import { authClient } from "@/lib/auth-client";
+import { authClient, getCachedSession, isLoggedOut } from "@/lib/auth-client";
 
 const AppLayout = () => {
   const { data } = authClient.useSession();
@@ -30,11 +30,9 @@ const AppLayout = () => {
 export const Route = createFileRoute("/_authorized-layout/_app-layout")({
   component: AppLayout,
   beforeLoad: async ({ location }) => {
-    const { data } = await authClient.getSession();
+    const sessionResult = await getCachedSession();
 
-    const isAuthenticated = !!data?.user;
-
-    if (!isAuthenticated) {
+    if (isLoggedOut(sessionResult)) {
       throw redirect({
         to: "/login",
         search: {

--- a/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
@@ -6,7 +6,7 @@ import { DesktopNavigation } from "@/components/DesktopNavigation";
 import { MobileHeader } from "@/components/MobileHeader";
 import { SearchInput } from "@/components/search/SearchInput";
 import { SORT_OPTIONS } from "@/hooks/search/useSearch";
-import { authClient } from "@/lib/auth-client";
+import { authClient, getCachedSession, isLoggedOut } from "@/lib/auth-client";
 import { settingsTable } from "@/lib/db/operations/settings";
 import { queryClient } from "@/lib/query";
 
@@ -46,11 +46,9 @@ export const Route = createFileRoute("/_authorized-layout/_search-layout")({
   component: AppLayout,
   validateSearch: zodValidator(filtersSchema),
   beforeLoad: async ({ location, search }) => {
-    const { data } = await authClient.getSession();
+    const sessionResult = await getCachedSession();
 
-    const isAuthenticated = !!data?.user;
-
-    if (!isAuthenticated) {
+    if (isLoggedOut(sessionResult)) {
       throw redirect({
         to: "/login",
         search: {
@@ -63,6 +61,11 @@ export const Route = createFileRoute("/_authorized-layout/_search-layout")({
       queryKey: settingsTable.getSettings.cacheOptions.queryKey,
       queryFn: settingsTable.getSettings.query,
     });
+
+    // `data` can be null on a transient error (429/network) that isn't a
+    // logout; skip the plan-gated redirect since we can't read the plan then.
+    const { data } = sessionResult;
+    if (!data?.user) return;
 
     const activeStatuses = ["active", "trialing", "past_due"];
     const isFreeUser =

--- a/apps/web/src/routes/_authorized-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/route.tsx
@@ -31,7 +31,7 @@ import { SchemaOutdatedBanner } from "@/components/SchemaOutdatedBanner";
 import { SyncIndicator } from "@/components/SyncIndicator";
 import { useSearch } from "@/hooks/search/useSearch";
 import { api } from "@/lib/api";
-import { authClient } from "@/lib/auth-client";
+import { getCachedSession, isLoggedOut } from "@/lib/auth-client";
 import { ensureDb, initDb } from "@/lib/db";
 import { DisplayError } from "@/lib/db/errors";
 import { dictionaryEntriesTable } from "@/lib/db/operations/dictionary-entries";
@@ -305,11 +305,13 @@ const AuthorizedLayoutError: ErrorRouteComponent = ({ error }) => {
 
 export const Route = createFileRoute("/_authorized-layout")({
   beforeLoad: async ({ location }) => {
-    const { data: session } = await authClient.getSession();
+    const sessionResult = await getCachedSession();
 
-    if (!session) {
+    if (isLoggedOut(sessionResult)) {
       throw redirect({ to: "/login", search: { redirect: location.href } });
     }
+
+    const { data: session } = sessionResult;
 
     if (session?.user) {
       Sentry.setUser({ id: session.user.id, email: session.user.email });

--- a/apps/web/src/routes/_authorized-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/route.tsx
@@ -307,7 +307,21 @@ export const Route = createFileRoute("/_authorized-layout")({
   beforeLoad: async ({ location }) => {
     const sessionResult = await getCachedSession();
 
+    if (sessionResult.error) {
+      // Distinguishes 429 (rate limit) vs 401 (real unauth) vs network/other.
+      Sentry.logger.warn("getSession failed", {
+        status: sessionResult.error.status,
+        statusText: sessionResult.error.statusText,
+        href: location.href,
+      });
+    }
+
     if (isLoggedOut(sessionResult)) {
+      Sentry.logger.warn("Redirecting to login", {
+        reason: "no_session",
+        status: sessionResult.error?.status ?? null,
+        href: location.href,
+      });
       throw redirect({ to: "/login", search: { redirect: location.href } });
     }
 
@@ -345,6 +359,10 @@ export const Route = createFileRoute("/_authorized-layout")({
           break;
 
         case "unauthorized":
+          Sentry.logger.warn("Redirecting to login", {
+            reason: "initdb_unauthorized",
+            href: location.href,
+          });
           throw redirect({ to: "/login", search: { redirect: location.href } });
 
         case "get_db_info_failed":

--- a/apps/web/src/routes/_unauthorized-layout/route.tsx
+++ b/apps/web/src/routes/_unauthorized-layout/route.tsx
@@ -21,6 +21,6 @@ export const Route = createFileRoute("/_unauthorized-layout")({
   component: Layout,
   beforeLoad: async () => {
     resetOramaDb();
-    await resetDb();
+    await resetDb("unauthorized_redirect");
   },
 });


### PR DESCRIPTION
## Problem

Users on the web app randomly hit a **"database must be connected"** error — the decks page, stats, and sometimes the review flow stop loading. Independent of deck count; no real logout, no writes involved.

Root cause is a chain:

1. Every route `beforeLoad` calls `authClient.getSession()`. Three of them nest on a single navigation (`_authorized-layout` + `_app-layout` + `_search-layout`), so one navigation = ~3 requests. Rapid navigation rate-limits the endpoint: `GET /api/auth/get-session` → **429**.
2. A 429 returns no `data`, so the `if (!session)` guard misreads a transient rate-limit as **"logged out"** and redirects to `/login`.
3. `/login` is under `_unauthorized-layout`, whose `beforeLoad` runs `resetDb()` → `db.close()`, releasing the OPFS `SyncAccessHandle` backing the local sync-wasm db.
4. In-flight reads then fail in the OPFS worker (`Cannot read properties of undefined (reading 'read')`), surfaced up the drizzle proxy as **"database must be connected"**.

## Fix

**Direct — don't treat a transient failure as logout.** New `isLoggedOut()` only redirects on a *confirmed* unauthenticated response (200 with null `data`, or 401). A 429 / network error no longer triggers the redirect + `resetDb()`. A genuine session expiry is still caught downstream by `initDb`'s own 401 handling.

**Trigger — stop hammering the endpoint.** New `getCachedSession()` routes `getSession()` through `queryClient.ensureQueryData` with a 5-min `staleTime` (matching the server-side cookie-cache `maxAge`). This dedupes the call across the nested `beforeLoad`s and across rapid navigation. `useLogout` already calls `queryClient.clear()`, so logout invalidates the cache; login routes stay on a direct `getSession()` (must be fresh, so no stale-null redirect loop).

> Note: Better Auth's cookie cache was already enabled server-side, but it can't fix this on its own — the `session_data` cookie is `httpOnly`, so the client can't read it and `getSession()` always makes a network round-trip. Reducing the number of client calls is the only lever.

### Why `getSession` isn't cached by default
`authClient.getSession()` is a raw fetch, not a TanStack Query, so it never touches the query cache — hence the wrapper. Better Auth's `useSession()` hook does cache (via its own nanostore) but is a React hook, unusable in `beforeLoad`.

## Files
- `apps/web/src/lib/auth-client.ts` — `getCachedSession` + `isLoggedOut` helpers
- `apps/web/src/routes/_authorized-layout/route.tsx`
- `apps/web/src/routes/_authorized-layout/_app-layout/route.tsx`
- `apps/web/src/routes/_authorized-layout/_search-layout/route.tsx` — added `data === null` guard before the plan-gated redirect (transient case)

## Verification
- `tsc --noEmit` clean
- Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session handling across app routes with cached session lookups for faster, more consistent navigation.
* **Bug Fixes**
  * Reduced unnecessary login redirects caused by temporary network or rate-limit errors.
  * Improved logout detection so only confirmed unauthenticated users are sent to the login page.
  * Prevented plan-related redirects from triggering when session data is briefly unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->