### PR TITLE
fix(cli): report the real HTTP error instead of guessing "rate limit"

### DIFF
--- a/apps/cli/src/lib/http.test.ts
+++ b/apps/cli/src/lib/http.test.ts
@@ -61,6 +61,38 @@ describe("readJsonResponse", () => {
     await expect(promise).rejects.toThrow(/rate limiting|try again/i);
   });
 
+  test("adds an auth hint for a 401", async () => {
+    const response = new Response("Unauthorized", {
+      status: 401,
+      statusText: "Unauthorized",
+    });
+
+    const promise = readJsonResponse({
+      response,
+      context: "Fetching database info",
+    });
+
+    // Should point the user at `bahar login`, and still surface the raw body.
+    await expect(promise).rejects.toThrow(/bahar login/);
+    await expect(promise).rejects.toThrow(/Unauthorized/);
+  });
+
+  test("does not label a non-429 as rate limited just because the body says so", async () => {
+    // Regression: a 401 whose body happens to contain rate-limit-ish phrasing
+    // must not be reported as rate limiting (the real error was auth).
+    const response = new Response("Please try again later", {
+      status: 401,
+      statusText: "Unauthorized",
+    });
+
+    const promise = readJsonResponse({
+      response,
+      context: "Fetching database info",
+    });
+
+    await expect(promise).rejects.not.toThrow(/rate limit/i);
+  });
+
   test("exposes the status on the thrown error", async () => {
     const response = new Response("nope", { status: 503 });
 

--- a/apps/cli/src/lib/http.ts
+++ b/apps/cli/src/lib/http.ts
@@ -17,16 +17,22 @@ const SNIPPET_LENGTH = 300;
 const bodySnippet = (body: string): string =>
   body.trim().replace(/\s+/g, " ").slice(0, SNIPPET_LENGTH);
 
-const looksRateLimited = ({
-  status,
-  body,
-}: {
-  status: number;
-  body: string;
-}): boolean =>
-  status === 429 ||
-  status === 503 ||
-  /rate limit|too many requests|try again/i.test(body);
+/**
+ * Status-based hint only. We deliberately do NOT sniff the body text for
+ * phrases like "rate limit" — an unrelated response (e.g. a 401 whose body
+ * happens to mention "try again") was being mislabeled as rate limiting,
+ * hiding the real error. Trust the status code, and always surface the raw
+ * body so the exact server message is visible.
+ */
+const statusHint = (status: number): string => {
+  if (status === 401 || status === 403) {
+    return " You're not authenticated or your session expired — run `bahar login` and try again.";
+  }
+  if (status === 429 || status === 503) {
+    return " The server is rate limiting or temporarily unavailable — wait a moment and try again.";
+  }
+  return "";
+};
 
 /**
  * Reads a fetch `Response` as JSON, turning the two failure modes that
@@ -49,11 +55,8 @@ export const readJsonResponse = async <T>({
   const body = await response.text();
 
   if (!response.ok) {
-    const hint = looksRateLimited({ status: response.status, body })
-      ? " The server is rate limiting or temporarily unavailable — wait a moment and try again."
-      : "";
     throw new HttpResponseError({
-      message: `${context} failed (${response.status} ${response.statusText}).${hint}${
+      message: `${context} failed (${response.status} ${response.statusText}).${statusHint(response.status)}${
         body ? ` Response: ${bodySnippet(body)}` : ""
       }`,
       status: response.status,
@@ -64,12 +67,9 @@ export const readJsonResponse = async <T>({
     return JSON.parse(body) as T;
   } catch {
     const contentType = response.headers.get("content-type") ?? "unknown";
-    const hint = looksRateLimited({ status: response.status, body })
-      ? " This looks like a rate-limit or maintenance page — wait a moment and try again."
-      : " The server returned a non-JSON response, which usually means a proxy/CDN error or maintenance page.";
     throw new HttpResponseError({
-      message: `${context} returned a non-JSON response (status ${response.status}, content-type ${contentType}).${hint}${
-        body ? ` Response: ${bodySnippet(body)}` : ""
+      message: `${context} returned a non-JSON response (status ${response.status}, content-type ${contentType}).${statusHint(response.status)} Response: ${
+        body ? bodySnippet(body) : "(empty body)"
       }`,
       status: response.status,
     });


### PR DESCRIPTION
## Problem

`bahar db-info` (and other CLI calls) reported **"Rate limit exceeded / maintenance page — wait a moment and try again"** when the real problem was that the user simply wasn't authenticated. Re-running `bahar login` fixed it, but the error message actively pointed the wrong way.

## Cause

`readJsonResponse` in `apps/cli/src/lib/http.ts` decided a response "looks rate limited" by matching the **body text** against `/rate limit|too many requests|try again/i`, independent of the status code. Any response whose body happened to contain "try again" (e.g. an auth failure) was mislabeled as rate limiting.

## Fix

- Remove the body-text heuristic.
- Derive the hint from the **status code** only: `401/403` → run `bahar login`; `429/503` → wait and retry.
- Always include the raw response body in the error so the exact server message is visible.

## Tests

Added coverage in `http.test.ts`: a `401` gets the login hint, and a non-429 whose body mentions "try again" is **not** labeled rate limited. `bun test` passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for CLI API responses so authentication and permission failures now show a clearer login hint.
  * Prevented rate-limit messaging from appearing on unrelated 401 errors, even when the response body contains similar wording.
  * Made non-JSON response errors more consistent by always including the response content or noting when it is empty.

* **Tests**
  * Added coverage for authentication and rate-limit hint handling to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->