### PR TITLE
fix(web): stop tag-filtered queries hanging the local DB on WASM

### DIFF
--- a/apps/web/src/lib/db/operations/decks.ts
+++ b/apps/web/src/lib/db/operations/decks.ts
@@ -72,7 +72,13 @@ export const decksTable = {
             eq(flashcards.is_hidden, false),
             ...(tags.length > 0
               ? [
-                  sql`EXISTS (SELECT 1 FROM json_each(${dictionaryEntries.tags}) WHERE value IN (${sql.join(
+                  // Non-correlated subquery, not `EXISTS (json_each(...))`.
+                  // The correlated form re-runs json_each per candidate row,
+                  // which the WASM SQLite build evaluates pathologically
+                  // slowly for decks matching many rows (effectively hangs,
+                  // wedging the single connection). Materializing the matching
+                  // entry ids once keeps it in the tens of ms.
+                  sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${sql.join(
                     tags.map((t) => sql`${t}`),
                     sql`, `
                   )}))`,

--- a/apps/web/src/lib/db/operations/flashcards.ts
+++ b/apps/web/src/lib/db/operations/flashcards.ts
@@ -92,7 +92,13 @@ export const flashcardsTable = {
         eq(flashcards.is_hidden, false),
         ...(tags.length > 0
           ? [
-              sql`EXISTS (SELECT 1 FROM json_each(${dictionaryEntries.tags}) WHERE value IN (${sql.join(
+              // Non-correlated subquery, not `EXISTS (json_each(...))`: the
+              // correlated form re-runs json_each per candidate row, which the
+              // WASM SQLite build evaluates pathologically slowly for tag
+              // filters matching many rows (effectively hangs, wedging the
+              // single connection). Materializing the matching entry ids once
+              // keeps it fast.
+              sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${sql.join(
                 tags.map((t) => sql`${t}`),
                 sql`, `
               )}))`,
@@ -520,7 +526,13 @@ export const flashcardsTable = {
         eq(flashcards.is_hidden, false),
         ...(tags.length > 0
           ? [
-              sql`EXISTS (SELECT 1 FROM json_each(${dictionaryEntries.tags}) WHERE value IN (${sql.join(
+              // Non-correlated subquery, not `EXISTS (json_each(...))`: the
+              // correlated form re-runs json_each per candidate row, which the
+              // WASM SQLite build evaluates pathologically slowly for tag
+              // filters matching many rows (effectively hangs, wedging the
+              // single connection). Materializing the matching entry ids once
+              // keeps it fast.
+              sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${sql.join(
                 tags.map((t) => sql`${t}`),
                 sql`, `
               )}))`,


### PR DESCRIPTION
## Symptom

Opening **Decks** (and sometimes Progress/stats) never loads — deck counts blank, sync indicator stuck on "Syncing…", and every subsequent DB operation hangs or fails. No error surfaces to the user. Reported across desktop, incognito, and mobile PWA. Started after the raw-SQL → drizzle migration.

## Root cause

The tag filter on the deck-stats and study-session queries was a **correlated** subquery:

```sql
EXISTS (SELECT 1 FROM json_each(dictionary_entries.tags) WHERE value IN (...))
```

The `@tursodatabase/sync-wasm` SQLite build re-evaluates that `json_each` **per candidate row**. Fine for filters matching few rows; **pathological** for one matching many. A real deck (`زاد الطالبين`, 2 tags, ~2000 matching cards) took **>114s in-browser** vs **~0.6s** against remote Turso.

The local DB is a **single connection**, so that one query monopolizes it: the page never loads and later operations hang or throw `database is busy` / `database must be connected`. (This ties together several recent Sentry issues on `/decks` and `/settings`.)

## Fix

Replace the correlated `EXISTS` with a **non-correlated** subquery that materializes the matching entry ids once:

```sql
dictionary_entries.id IN (
  SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt
  WHERE jt.value IN (...)
)
```

Applied at all three affected sites: `decks.ts` (deck list stats) and `flashcards.ts` ×2 (tag-filtered fetches). The other `json_each` sites already use the JOIN form.

## Validation

Reproduced against a copy of the affected data via a headless browser: before, `زاد الطالبين` hung >114s and wedged the connection; after, **all 7 decks render in 22–66ms** and navigating to Progress immediately afterward works (connection not wedged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)