### PR TITLE
test(web): cover multi-tag deck filters

### DIFF
--- a/apps/web/src/lib/db/operations/decks.browser.test.ts
+++ b/apps/web/src/lib/db/operations/decks.browser.test.ts
@@ -331,6 +331,49 @@ describe("decksTable", () => {
 
         expect(result?.total_hits).toBe(2);
       });
+
+      it("matches an entry that has ANY of several specified tags (OR)", async () => {
+        // Multi-tag filters are what surfaced the json_each perf bug; this
+        // pins down the OR semantics of the tag subquery.
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"] },
+        });
+
+        const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: fooEntry.id });
+
+        const barEntry = await insertDictionaryEntry(testDb, { tags: ["bar"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: barEntry.id });
+
+        const bazEntry = await insertDictionaryEntry(testDb, { tags: ["baz"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: bazEntry.id });
+
+        const decks = await decksTable.list.query({});
+        const result = decks.find((d) => d.id === deck.id);
+
+        // foo + bar match, baz does not.
+        expect(result?.total_hits).toBe(2);
+      });
+
+      it("counts an entry with several matching tags only once", async () => {
+        // Regression guard for the tag filter rewrite: the subquery joins
+        // json_each(tags), so an entry matching multiple filter tags yields
+        // its id more than once inside the IN (...) set. total_hits is
+        // COUNT(DISTINCT flashcards.id), so the flashcard must still count once.
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"] },
+        });
+
+        const bothEntry = await insertDictionaryEntry(testDb, {
+          tags: ["foo", "bar"],
+        });
+        await insertFlashcard(testDb, { dictionary_entry_id: bothEntry.id });
+
+        const decks = await decksTable.list.query({});
+        const result = decks.find((d) => d.id === deck.id);
+
+        expect(result?.total_hits).toBe(1);
+      });
     });
 
     describe("show_reverse", () => {


### PR DESCRIPTION
Regression coverage for the tag-filter rewrite in `decksTable.list` (#51) — specifically the multi-tag path that surfaced the `json_each` perf issue:

- an entry matching **any** of several filter tags is counted (OR semantics)
- an entry matching **multiple** filter tags is counted **once**, not per tag — the rewritten subquery joins `json_each(tags)`, so the entry id appears multiple times inside `IN (...)`; `total_hits` is `COUNT(DISTINCT flashcards.id)` so it must still dedupe

Both run against the real SQLite test DB. Full file: 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)