### PR TITLE
fix(api): make request log fields searchable in Sentry

### DIFF
--- a/apps/api/src/middleware/http-logger.ts
+++ b/apps/api/src/middleware/http-logger.ts
@@ -2,7 +2,33 @@ import { Elysia } from "elysia";
 import { LogCategory, logger } from "../utils/logger";
 
 /**
+ * Resolves the HTTP status code from an Elysia response.
+ *
+ * Two response shapes reach `onAfterResponse`:
+ *  - a native `Response` (e.g. from a mounted better-auth handler) exposes
+ *    `status`
+ *  - an `ElysiaCustomStatusResponse` produced by `status(4xx)` in a macro
+ *    exposes `code` (not `status`)
+ *
+ * We check both, then fall back to `set.status`, so 401/403/429 responses are
+ * logged with their real status instead of defaulting to 200.
+ */
+const resolveStatus = (response: unknown, setStatus: unknown): number => {
+  const fromResponse = (response as { status?: unknown; code?: unknown }) ?? {};
+
+  if (typeof fromResponse.status === "number") return fromResponse.status;
+  if (typeof fromResponse.code === "number") return fromResponse.code;
+  if (typeof setStatus === "number") return setStatus;
+
+  return 200;
+};
+
+/**
  * Custom HTTP logging middleware that replicates pino-http functionality.
+ *
+ * Fields are emitted flat (method, path, status, route, responseTime) so they
+ * survive forwarding to Sentry Logs as searchable attributes. Request headers,
+ * query params and bodies are deliberately not logged to stay PII-safe.
  */
 export const httpLogger = new Elysia({ name: "http-logger" })
   .derive({ as: "global" }, ({ request }) => ({
@@ -17,79 +43,70 @@ export const httpLogger = new Elysia({ name: "http-logger" })
       {
         category: LogCategory.APPLICATION,
         event: "request_received",
-        req: serializeRequest(request),
+        method: request.method,
+        path,
       },
       "request received"
     );
   })
   .onAfterResponse(
     { as: "global" },
-    ({ request, requestPath, requestStartTime, response }) => {
+    ({ request, requestPath, requestStartTime, response, route, set }) => {
       if (request.method === "OPTIONS" || requestPath === "/health") return;
 
       const duration = Date.now() - requestStartTime;
-      const status = (response as { status?: number })?.status ?? 200;
+      const status = resolveStatus(response, set.status);
       const level = status >= 500 ? "error" : "info";
 
       logger[level](
         {
           category: LogCategory.APPLICATION,
           event: "request_processed",
+          method: request.method,
+          path: requestPath,
+          route,
+          status,
           responseTime: duration,
-          req: serializeRequest(request),
-          res: { statusCode: status },
         },
         "request completed"
       );
     }
   )
-  .onError(({ request, requestPath, error, code, requestStartTime, set }) => {
-    if (request.method === "OPTIONS" || requestPath === "/health") return;
+  .onError(
+    ({ request, requestPath, error, code, route, requestStartTime, set }) => {
+      if (request.method === "OPTIONS" || requestPath === "/health") return;
 
-    const duration = Date.now() - (requestStartTime ?? Date.now());
+      const duration = Date.now() - (requestStartTime ?? Date.now());
 
-    // Map Elysia error codes to HTTP status codes
-    const statusCode =
-      code === "NOT_FOUND"
-        ? 404
-        : code === "VALIDATION"
-          ? 400
-          : code === "PARSE"
+      // Map Elysia error codes to HTTP status codes
+      const status =
+        code === "NOT_FOUND"
+          ? 404
+          : code === "VALIDATION"
             ? 400
-            : code === "INVALID_COOKIE_SIGNATURE"
+            : code === "PARSE"
               ? 400
-              : typeof set.status === "number"
-                ? set.status
-                : 500;
+              : code === "INVALID_COOKIE_SIGNATURE"
+                ? 400
+                : typeof set.status === "number"
+                  ? set.status
+                  : 500;
 
-    const level = statusCode >= 500 ? "error" : "warn";
+      const level = status >= 500 ? "error" : "warn";
 
-    logger[level](
-      {
-        category: LogCategory.APPLICATION,
-        event: "request_failed",
-        responseTime: duration,
-        req: serializeRequest(request),
-        res: { statusCode },
-        err: code !== "NOT_FOUND" ? error : undefined,
-      },
-      "request failed"
-    );
-  });
-
-export function serializeRequest(request: Request) {
-  const url = new URL(request.url);
-
-  return {
-    method: request.method,
-    url: request.url,
-    path: url.pathname,
-    query: Object.fromEntries(url.searchParams),
-    headers: {
-      "user-agent": request.headers.get("user-agent"),
-      "content-length": request.headers.get("content-length"),
-      accept: request.headers.get("accept"),
-      referer: request.headers.get("referer"),
-    },
-  };
-}
+      logger[level](
+        {
+          category: LogCategory.APPLICATION,
+          event: "request_failed",
+          method: request.method,
+          path: requestPath,
+          route,
+          status,
+          responseTime: duration,
+          code,
+          err: code !== "NOT_FOUND" ? error : undefined,
+        },
+        "request failed"
+      );
+    }
+  );

--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -42,6 +42,42 @@ const sentryLogMethods: Record<
   fatal: Sentry.logger.fatal,
 };
 
+const isPrimitive = (
+  value: unknown
+): value is string | number | boolean =>
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean";
+
+/**
+ * Sentry log attributes are only searchable when they are flat, primitive
+ * top-level keys. Nested objects (e.g. `req.path`, `res.statusCode`) get
+ * stringified into a single opaque attribute and can't be filtered on, so we
+ * flatten them into dot-notation keys before forwarding. Arrays and other
+ * non-primitives are dropped to keep attributes flat and low-noise.
+ */
+const flattenLogAttributes = (
+  input: Record<string, unknown>,
+  prefix = "",
+  out: Record<string, string | number | boolean> = {}
+): Record<string, string | number | boolean> => {
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue;
+
+    const attributeKey = prefix ? `${prefix}.${key}` : key;
+
+    if (isPrimitive(value)) {
+      out[attributeKey] = value;
+    } else if (value instanceof Error) {
+      out[attributeKey] = value.message;
+    } else if (typeof value === "object" && !Array.isArray(value)) {
+      flattenLogAttributes(value as Record<string, unknown>, attributeKey, out);
+    }
+  }
+
+  return out;
+};
+
 export const logger = pino({
   level: config.LOG_LEVEL,
   timestamp: pino.stdTimeFunctions.isoTime,
@@ -92,8 +128,12 @@ export const logger = pino({
 
         if (typeof first === "string") {
           sentryLog(first);
-        } else {
-          sentryLog(typeof second === "string" ? second : "", first);
+        } else if (first && typeof first === "object") {
+          const message = typeof second === "string" ? second : "";
+          sentryLog(
+            message,
+            flattenLogAttributes(first as Record<string, unknown>)
+          );
         }
       }
 


### PR DESCRIPTION
## What

API request logs already carried `method`/`path`/`status`, but they were nested under `req`/`res` objects. Sentry Logs only index flat primitive attributes, so the nesting collapsed into one opaque blob and **none of the fields were filterable** — you couldn't query `path` or `status` in Sentry.

## Changes

- **Flatten forwarded attributes** (`logger.ts`) into dot-notation primitive keys before handing them to `Sentry.logger.*`.
- **Emit HTTP fields flat** (`http-logger.ts`): `method`, `path`, `status`, `route`, `responseTime` — now searchable Sentry attributes.
- **Fix status extraction**: a native `status(4xx)` call produces an `ElysiaCustomStatusResponse` exposing `code`, not `status`. So 401/403/429 from the auth and rate-limit macros (including `GET /api/auth/get-session`) were being logged as **200**. Now resolves from `status` → `code` → `set.status`.
- **PII cleanup**: dropped request headers and query params from logs. `/health` + OPTIONS still skipped.

## Result

Query `path:"/api/auth/get-session" status:429` in Sentry Logs and jump to the same `trace_id` as the frontend error. `trace_id` correlation is unchanged (auto-attached by Sentry's active span, not pino).

## Verification

Type-check clean. Not exercised at runtime (worktree lacks `node_modules`) — recommend hitting a rate-limited endpoint post-merge to eyeball the attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP log status detection so responses are recorded more accurately across different response formats.
  * Simplified request logging output to include only the most relevant fields, making logs easier to read and search.
  * Refined error logging to capture consistent status, route, timing, and error details in a flatter format.
  * Enhanced log forwarding so structured data is converted into searchable fields more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->