### PR TITLE
feat(web): headless auth for e2e tests + agent browser drivers (BAH-156)

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -25,3 +25,9 @@ dist-ssr
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Playwright / e2e
+/e2e/.auth
+/test-results
+/playwright-report
+/playwright/.cache

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,100 @@
+# e2e / headless auth
+
+Playwright e2e harness. The key piece is **headless auth**: it logs a user in
+with no human, no OAuth redirect, and no email inbox, so tests and agents can
+drive the app as an authenticated user.
+
+## How auth works
+
+Production auth is GitHub/Apple OAuth + email OTP via Resend — neither is
+automatable. Instead, `e2e/lib/mint.mjs` mints a real session server-side:
+
+1. `POST /api/auth/email-otp/send-verification-otp` (`type: "sign-in"`).
+2. Reads the plaintext OTP straight from the central `verifications` table
+   (better-auth stores it unhashed by default).
+3. `POST /api/auth/sign-in/email-otp` → captures the `Set-Cookie` session cookie.
+
+The cookies are written to `e2e/.auth/state.json` (gitignored) as a Playwright
+`storageState`. `playwright.config.ts` loads it via `use.storageState`, and the
+`_pw-*.mjs` agent drivers load the same file — so login happens once and is
+reused everywhere.
+
+> The OTP read couples the harness to a better-auth internal format
+> (`sign-in-otp-<email>` identifier, `<otp>:<attempts>` value). A better-auth
+> major could change it; see BAH-156 for the test-mode-capture alternative.
+
+## Test user & data
+
+A **single** fixed test user (`E2E_TEST_EMAIL`, default `e2e@bahar.test`) is
+shared across the whole Playwright suite **and** agent runs. Deliberate: one
+stable user means one provisioned Turso DB created once and reused, so dev runs
+don't accumulate real cloud DBs (see `createNewUserDb` in
+`apps/api/src/clients/turso.ts`, which hits the Turso Platform API regardless of
+`NODE_ENV`). No cleanup script needed.
+
+Because the user and its DB are shared, scenario data must be **reset to a known
+baseline**, not just appended — tracked in the separate e2e data-seeding ticket.
+Things that ticket owns:
+
+- **Shared mutable state** — a test that writes pollutes later tests and the
+  next run; seeding must truncate + load fixtures, not add.
+- **Parallelism** — currently forced serial (`fullyParallel: false`, `workers: 1`)
+  because concurrent tests would race on the shared data. Re-enable parallelism
+  there once per-test / per-worker isolation exists.
+- **Sync layering** — the web local DB (sync-wasm/OPFS) is a separate copy synced
+  from the remote user DB on a ~60s cycle, so seeding the remote isn't instantly
+  visible. Decide remote-seed + force-sync vs. seeding the browser's local DB
+  directly (overlaps BAH-139, multi-tab OPFS).
+
+## Prerequisites
+
+The **backend must be running** — global-setup mints against it:
+
+```bash
+make local-db        # central DB (verifications table) on :8080
+make tunnel          # exposes the API at https://local.bahar.dev
+pnpm run dev         # API + web
+```
+
+The web dev server is started automatically by Playwright
+(`reuseExistingServer` locally).
+
+On a fresh clone, install the Chromium binary once:
+
+```bash
+pnpm --filter web test:e2e:install   # playwright install chromium
+```
+
+## Running
+
+```bash
+pnpm --filter web test:e2e        # run the suite (mints session first)
+pnpm --filter web test:e2e:ui     # Playwright UI mode
+pnpm --filter web e2e:auth        # (re)mint storageState only
+pnpm --filter web type-check:e2e  # type-check the harness (e2e/tsconfig.json)
+node apps/web/e2e/_pw-example.mjs # example agent browser driver
+```
+
+The e2e sources live outside the app's `tsc` scope (`apps/web/tsconfig.json`
+only includes `src`), so they have their own `e2e/tsconfig.json`
+(Node + `@playwright/test` types). The mint types are a `.d.mts` sidecar so they
+resolve for the `./lib/mint.mjs` import.
+
+## Config (env, with local-dev defaults)
+
+| Var                   | Default                     |
+| --------------------- | --------------------------- |
+| `E2E_API_BASE_URL`    | `https://local.bahar.dev`   |
+| `E2E_WEB_BASE_URL`    | `http://localhost:5173`     |
+| `E2E_CENTRAL_DB_URL`  | `http://localhost:8080`     |
+| `E2E_CENTRAL_DB_TOKEN`| _(empty — local turso dev)_ |
+| `E2E_TEST_EMAIL`      | `e2e@bahar.test`            |
+
+The test user is created on first sign-in (sign-up is enabled for email OTP).
+
+## Agent drivers
+
+`_pw-*.mjs` are standalone browser drivers (no test runner). Copy
+`_pw-example.mjs` to `_pw-<task>.mjs`, keep the storageState loading, and replace
+the "drive the app" section. They regenerate the session automatically if
+`e2e/.auth/state.json` is missing.

--- a/apps/web/e2e/_pw-example.mjs
+++ b/apps/web/e2e/_pw-example.mjs
@@ -1,0 +1,51 @@
+// Example agent browser driver.
+//
+// Standalone script (no Playwright test runner) that an agent can run to drive
+// the app as a logged-in user:  `node e2e/_pw-example.mjs`
+//
+// Reuses the SAME headless-auth session as the e2e suite: it loads the
+// storageState written by mint.mjs, regenerating it on the fly if it's missing.
+// Copy this file to `_pw-<task>.mjs` and replace the "drive the app" section.
+
+import { access } from "node:fs/promises";
+import { chromium } from "playwright";
+import {
+  resolveE2eConfig,
+  STORAGE_STATE_PATH,
+  writeStorageState,
+} from "./lib/mint.mjs";
+
+const ensureStorageState = async (config) => {
+  try {
+    await access(STORAGE_STATE_PATH);
+  } catch {
+    console.log("[pw] no storageState found, minting a fresh session...");
+    await writeStorageState(config);
+  }
+};
+
+const main = async () => {
+  const config = resolveE2eConfig();
+  await ensureStorageState(config);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    storageState: STORAGE_STATE_PATH,
+  });
+  const page = await context.newPage();
+
+  // --- drive the app (logged in) --------------------------------------------
+  await page.goto(config.webBaseUrl);
+  await page.waitForLoadState("networkidle");
+  await page.screenshot({ path: "e2e/.auth/example.png", fullPage: true });
+  console.log(`[pw] loaded ${config.webBaseUrl} as ${config.email}`);
+  // --------------------------------------------------------------------------
+
+  await context.close();
+  await browser.close();
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+const CONSENT_DISMISS_BUTTON = /no thanks/i;
+const DICTIONARY_HEADING = /your dictionary/i;
+const LOGIN_URL = /\/login/;
+
+// Smoke test proving the headless-auth storageState (minted in global-setup)
+// lands the browser in an authenticated session. BAH-113 builds the real
+// happy-path suite on top of this.
+test("loads the app as an authenticated user", async ({ page }) => {
+  await page.goto("/");
+
+  const dismissConsent = page.getByRole("button", {
+    name: CONSENT_DISMISS_BUTTON,
+  });
+  const dictionaryHeading = page.getByRole("heading", {
+    name: DICTIONARY_HEADING,
+  });
+
+  // A user who hasn't answered the newsletter prompt gets a "Stay updated?"
+  // modal on top of the app; while open it makes the rest of the page inert,
+  // hiding the dictionary heading from the accessibility tree. Wait for
+  // whichever renders first (no fixed penalty either way) and dismiss the modal
+  // only if it actually appeared. (Deterministic handling of this consent state
+  // belongs to the seeding ticket.) The timeout covers first-load local DB
+  // (sync-wasm) init.
+  await expect(dismissConsent.or(dictionaryHeading).first()).toBeVisible({
+    timeout: 15_000,
+  });
+  if (await dismissConsent.isVisible()) {
+    await dismissConsent.click();
+  }
+
+  // The authenticated dictionary landing renders a "Your Dictionary" <h1>;
+  // an unauthenticated session would instead be redirected to /login.
+  await expect(dictionaryHeading).toBeVisible();
+
+  // Sanity: we were not bounced to the login route.
+  await expect(page).not.toHaveURL(LOGIN_URL);
+});

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,17 @@
+import type { FullConfig } from "@playwright/test";
+// mint.mjs is plain ESM shared with the _pw-*.mjs agent drivers; types come
+// from the sibling mint.d.ts.
+import { resolveE2eConfig, writeStorageState } from "./lib/mint.mjs";
+
+/**
+ * Playwright global setup: mints a real session cookie once before the suite
+ * runs and writes it to the storageState file that `use.storageState` loads.
+ */
+const globalSetup = async (_config: FullConfig): Promise<void> => {
+  const config = resolveE2eConfig();
+  const path = await writeStorageState(config);
+
+  console.log(`[e2e] minted session for ${config.email} -> ${path}`);
+};
+
+export default globalSetup;

--- a/apps/web/e2e/lib/mint.d.mts
+++ b/apps/web/e2e/lib/mint.d.mts
@@ -1,0 +1,31 @@
+import type { Cookie } from "@playwright/test";
+
+export interface E2eConfig {
+  /** Base URL of the running API, e.g. https://local.bahar.dev */
+  apiBaseUrl: string;
+  /** Base URL of the web app under test, e.g. http://localhost:5173 */
+  webBaseUrl: string;
+  /** Central DB URL holding the `verifications` table, e.g. http://localhost:8080 */
+  centralDbUrl: string;
+  /** Auth token for the central DB; undefined for the local turso dev server */
+  centralDbToken: string | undefined;
+  /** Email of the user to sign in (created on first run when sign-up is enabled) */
+  email: string;
+}
+
+export interface StorageState {
+  cookies: Cookie[];
+  origins: never[];
+}
+
+/** Absolute path of the Playwright storageState file this module reads/writes. */
+export const STORAGE_STATE_PATH: string;
+
+/** Resolves harness config from env with local-dev defaults. */
+export function resolveE2eConfig(): E2eConfig;
+
+/** Runs the headless sign-in flow and returns a Playwright storageState object. */
+export function mintSession(config?: E2eConfig): Promise<StorageState>;
+
+/** Mints a session, writes it to `STORAGE_STATE_PATH`, and returns that path. */
+export function writeStorageState(config?: E2eConfig): Promise<string>;

--- a/apps/web/e2e/lib/mint.mjs
+++ b/apps/web/e2e/lib/mint.mjs
@@ -1,0 +1,207 @@
+// Headless session minting for e2e tests and agent browser drivers.
+//
+// Logs a user in WITHOUT a human: no OAuth redirect, no email inbox. The flow
+// is entirely server-side against the running API:
+//
+//   1. POST /api/auth/email-otp/send-verification-otp  (type: "sign-in")
+//   2. Read the plaintext OTP straight from the central `verifications` table
+//      (better-auth stores it unhashed by default; see readOtp below).
+//   3. POST /api/auth/sign-in/email-otp  ->  grab the Set-Cookie session cookie.
+//
+// The resulting cookies are written as a Playwright storageState file that both
+// `playwright.config.ts` (via global-setup) and the `_pw-*.mjs` agent drivers
+// load, so a login happens once and is reused everywhere.
+//
+// Kept as plain ESM (not .ts) so the .mjs agent drivers can import it directly
+// with no build step. Types live alongside in `mint.d.ts`.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { connect } from "@tursodatabase/serverless";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Path of the Playwright storageState file this module reads/writes. */
+export const STORAGE_STATE_PATH = resolve(here, "../.auth/state.json");
+
+// better-auth 1.4.19 stores the sign-in OTP in `verifications` keyed by this
+// identifier prefix, with value "<otp>:<attempts>" (plaintext — storeOTP is not
+// overridden in apps/api/src/auth.ts). Coupled to better-auth internals; a major
+// upgrade could change it. See BAH-156 for the test-mode-capture alternative.
+const OTP_IDENTIFIER_PREFIX = "sign-in-otp-";
+
+/**
+ * Resolves harness config from env with local-dev defaults. The defaults mirror
+ * apps/web/.env (VITE_API_BASE_URL), apps/api/.env (DATABASE_URL) and the vite
+ * dev server port.
+ */
+export const resolveE2eConfig = () => ({
+  apiBaseUrl: process.env.E2E_API_BASE_URL ?? "https://local.bahar.dev",
+  webBaseUrl: process.env.E2E_WEB_BASE_URL ?? "http://localhost:5173",
+  centralDbUrl: process.env.E2E_CENTRAL_DB_URL ?? "http://localhost:8080",
+  centralDbToken: process.env.E2E_CENTRAL_DB_TOKEN || undefined,
+  email: process.env.E2E_TEST_EMAIL ?? "e2e@bahar.test",
+});
+
+const sendOtp = async ({ apiBaseUrl, email }) => {
+  const response = await fetch(
+    `${apiBaseUrl}/api/auth/email-otp/send-verification-otp`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, type: "sign-in" }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `send-verification-otp failed: ${response.status} ${await response.text()}`
+    );
+  }
+};
+
+const readOtp = async ({ centralDbUrl, centralDbToken, email }) => {
+  const connection = connect({ url: centralDbUrl, authToken: centralDbToken });
+
+  try {
+    const { rows } = await connection.execute(
+      "SELECT value FROM verifications WHERE identifier = ? ORDER BY created_at DESC LIMIT 1",
+      [`${OTP_IDENTIFIER_PREFIX}${email}`]
+    );
+
+    const [row] = rows;
+
+    if (!row) {
+      throw new Error(
+        `No OTP found in verifications for ${email}. Is the API pointed at the same central DB (${centralDbUrl})?`
+      );
+    }
+
+    // value is "<otp>:<attempts>"
+    return String(row.value).split(":")[0];
+  } finally {
+    await connection.close();
+  }
+};
+
+const signIn = async ({ apiBaseUrl, email, otp }) => {
+  const response = await fetch(`${apiBaseUrl}/api/auth/sign-in/email-otp`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, otp }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `sign-in/email-otp failed: ${response.status} ${await response.text()}`
+    );
+  }
+
+  const setCookieHeaders = response.headers.getSetCookie();
+
+  if (setCookieHeaders.length === 0) {
+    throw new Error("sign-in/email-otp returned no Set-Cookie header");
+  }
+
+  return setCookieHeaders;
+};
+
+const toPlaywrightSameSite = (raw) => {
+  switch (raw?.toLowerCase()) {
+    case "none":
+      return "None";
+    case "strict":
+      return "Strict";
+    default:
+      return "Lax";
+  }
+};
+
+const parseSetCookie = ({ header, fallbackDomain, fallbackSecure }) => {
+  const [pair, ...rawAttributes] = header.split(";").map((part) => part.trim());
+  const separator = pair.indexOf("=");
+  const name = pair.slice(0, separator);
+  const value = pair.slice(separator + 1);
+
+  const attributes = new Map();
+  for (const attribute of rawAttributes) {
+    const separatorIndex = attribute.indexOf("=");
+    if (separatorIndex === -1) {
+      attributes.set(attribute.toLowerCase(), "");
+    } else {
+      attributes.set(
+        attribute.slice(0, separatorIndex).toLowerCase(),
+        attribute.slice(separatorIndex + 1)
+      );
+    }
+  }
+
+  const maxAge = attributes.get("max-age");
+  const expires =
+    maxAge === undefined
+      ? -1
+      : Math.floor(Date.now() / 1000) + Number.parseInt(maxAge, 10);
+
+  return {
+    name,
+    value,
+    domain: attributes.get("domain") ?? fallbackDomain,
+    path: attributes.get("path") ?? "/",
+    expires,
+    httpOnly: attributes.has("httponly"),
+    secure: attributes.has("secure") || fallbackSecure,
+    sameSite: toPlaywrightSameSite(attributes.get("samesite")),
+  };
+};
+
+/**
+ * Runs the full headless sign-in flow and returns a Playwright storageState
+ * object. Does not touch the filesystem — see `writeStorageState`.
+ */
+export const mintSession = async (config = resolveE2eConfig()) => {
+  const { apiBaseUrl, centralDbUrl, centralDbToken } = config;
+  const email = config.email.toLowerCase();
+
+  await sendOtp({ apiBaseUrl, email });
+  const otp = await readOtp({ centralDbUrl, centralDbToken, email });
+  const setCookieHeaders = await signIn({ apiBaseUrl, email, otp });
+
+  const apiUrl = new URL(apiBaseUrl);
+  const cookies = setCookieHeaders.map((header) =>
+    parseSetCookie({
+      header,
+      fallbackDomain: apiUrl.hostname,
+      fallbackSecure: apiUrl.protocol === "https:",
+    })
+  );
+
+  return { cookies, origins: [] };
+};
+
+/**
+ * Mints a session and writes it to `STORAGE_STATE_PATH`, creating the parent
+ * directory if needed. Returns the path written.
+ */
+export const writeStorageState = async (config = resolveE2eConfig()) => {
+  const storageState = await mintSession(config);
+  await mkdir(dirname(STORAGE_STATE_PATH), { recursive: true });
+  await writeFile(
+    STORAGE_STATE_PATH,
+    `${JSON.stringify(storageState, null, 2)}\n`
+  );
+  return STORAGE_STATE_PATH;
+};
+
+// Allow `node e2e/lib/mint.mjs` (wired as the `e2e:auth` script) to regenerate
+// the storageState on demand, independent of a Playwright run.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  writeStorageState()
+    .then((path) => {
+      console.log(`Wrote storageState to ${path}`);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/apps/web/e2e/tsconfig.json
+++ b/apps/web/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@bahar/typescript-config/vite.json",
+  "compilerOptions": {
+    "types": ["node", "@playwright/test"],
+    "lib": ["ESNext", "DOM"],
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["**/*.ts", "**/*.mts", "**/*.mjs", "../playwright.config.ts"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,11 @@
     "test:watch": "vitest run --watch",
     "test:browser": "vitest run --project=browser",
     "test:browser:watch": "vitest --project=browser",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install chromium",
+    "type-check:e2e": "tsc -p e2e/tsconfig.json --noEmit",
+    "e2e:auth": "node e2e/lib/mint.mjs",
     "wrangler:dev": "wrangler pages dev --port 5173"
   },
   "dependencies": {
@@ -69,9 +74,11 @@
     "@lingui/conf": "^5.3.2",
     "@lingui/swc-plugin": "^5.10.0",
     "@lingui/vite-plugin": "^5.3.2",
+    "@playwright/test": "^1.61.1",
     "@swc/core": "1.11.21",
     "@tanstack/router-devtools": "^1.91.3",
     "@tanstack/router-plugin": "^1.91.1",
+    "@tursodatabase/serverless": "^0.2.4",
     "@types/bun": "^1.3.11",
     "@types/node": "^20.10.6",
     "@types/react": "^19.0.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+import { resolveE2eConfig, STORAGE_STATE_PATH } from "./e2e/lib/mint.mjs";
+
+const { webBaseUrl } = resolveE2eConfig();
+
+// The backend (API at E2E_API_BASE_URL + its central DB) must be running before
+// the suite starts — global-setup mints a session against it. See e2e/README.md.
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.spec\.ts/,
+  globalSetup: "./e2e/global-setup.ts",
+  // Serial for now: all tests share one test user + one DB (see e2e/README.md).
+  // The data-seeding ticket re-enables parallelism once it adds per-test/worker
+  // isolation.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: webBaseUrl,
+    storageState: STORAGE_STATE_PATH,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm run dev",
+    url: webBaseUrl,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,6 +668,9 @@ importers:
       '@lingui/vite-plugin':
         specifier: ^5.3.2
         version: 5.3.2(typescript@5.8.3)(vite@6.4.1)
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@swc/core':
         specifier: 1.11.21
         version: 1.11.21
@@ -677,6 +680,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.91.1
         version: 1.91.1(vite@6.4.1)
+      '@tursodatabase/serverless':
+        specifier: ^0.2.4
+        version: 0.2.4
       '@types/bun':
         specifier: ^1.3.11
         version: 1.3.11
@@ -8076,6 +8082,14 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@playwright/test@1.61.1:
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.61.1
+    dev: true
 
   /@polar-sh/better-auth@1.8.1(@polar-sh/sdk@0.42.5)(@stripe/react-stripe-js@4.0.2)(@stripe/stripe-js@7.9.0)(@types/react-dom@19.0.0)(@types/react@19.1.17)(better-auth@1.4.19)(react-dom@19.1.0)(react-is@19.2.5)(react@19.1.0)(redux@5.0.1)(zod@4.3.6):
     resolution: {integrity: sha512-wZjF1xcxw1+blnR8JspPwZ0WhwoHkG4C2oFhVzb1RJKQfwTBjSmnrBftjaV6D3WFHDnrs0wFPnW/YHXzg8paOA==}


### PR DESCRIPTION
## What

Foundation for Playwright e2e tests and agent browser driving: log in **without a human** (no OAuth redirect, no email inbox), then reuse the session everywhere.

Production auth is GitHub/Apple OAuth + email OTP via Resend with `emailAndPassword` disabled — none of it is automatable. Instead, `e2e/lib/mint.mjs` mints a real session cookie entirely server-side against the running API:

1. `POST /api/auth/email-otp/send-verification-otp` (`type: "sign-in"`)
2. Read the plaintext OTP from the central `verifications` table (better-auth stores it unhashed by default) via `@tursodatabase/serverless`
3. `POST /api/auth/sign-in/email-otp` → capture the `Set-Cookie` session cookie → write `e2e/.auth/state.json`

Playwright loads that storageState via `use.storageState`; the `_pw-*.mjs` agent drivers load the same file. The mint logic is plain ESM (types in a `.d.mts` sidecar) so the TS harness and the `.mjs` drivers share one module with no build step.

## Contents

- `playwright.config.ts` — baseURL, storageState, globalSetup, auto web server. Serial (`fullyParallel: false`, `workers: 1`) because all tests share one user + DB.
- `e2e/global-setup.ts` — mints the session before the suite.
- `e2e/lib/mint.mjs` (+ `mint.d.mts`) — the mint flow; also runnable as `e2e:auth`.
- `e2e/_pw-example.mjs` — agent browser-driver template (self-mints if storageState is missing).
- `e2e/auth.spec.ts` — smoke test: asserts the authenticated dictionary renders (dismisses the consent modal if shown).
- `e2e/tsconfig.json` — the e2e sources are outside the app's `tsc` scope, so they get their own Node + `@playwright/test` config.
- `e2e/README.md` — flow, prerequisites, config table, single-shared-user rationale, caveats.
- Scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:install`, `type-check:e2e`, `e2e:auth`. Deps: `@playwright/test`, `@tursodatabase/serverless`.

## Decisions

- **OTP source = DB-read**, not a test-mode capture in the API. Zero production-code change. Couples the harness to a better-auth internal format (identifier prefix, `<otp>:<attempts>` value); documented in the README with the alternative.
- **Single fixed test user** (`e2e@bahar.test`) shared across the suite and agent runs → one provisioned Turso DB, created once and reused, so dev runs don't accumulate real cloud DBs. No cleanup script needed.

## Verified

Locally, backend up: fresh mint → Chromium loads storageState → `get-session` returns the user → `auth.spec.ts` passes (~1.9s). `tsc -p e2e/tsconfig.json` and biome clean.

## Follow-ups (separate tickets)

- BAH-113 — real happy-path e2e suite.
- Data seeding/reset for the shared user (owns: baseline reset, re-enabling parallelism, remote-seed-vs-local-seed under sync-wasm/OPFS — overlaps BAH-139).
- CI wiring (needs API + tunnel + Turso + secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end browser testing support with a reusable signed-in session and an example standalone browser script.

* **Tests**
  * Added a new authenticated smoke test to confirm the app loads correctly for signed-in users.
  * Configured the browser test suite to run consistently with shared setup and Chromium coverage.

* **Documentation**
  * Added setup and usage guidance for running, refreshing, and extending the browser test workflow.

* **Chores**
  * Updated project scripts and dependencies to support the new browser testing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->