### PR TITLE
feat(mobile): add Sentry error, tracing, and structured logging

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Bahar",
     "slug": "bahar",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "orientation": "portrait",
     "scheme": "bahar",
     "userInterfaceStyle": "automatic",
@@ -81,7 +81,7 @@
     },
     "owner": "shunsei",
     "runtimeVersion": {
-      "policy": "fingerprint"
+      "policy": "appVersion"
     },
     "updates": {
       "url": "https://u.expo.dev/b6d34ce9-eea1-4afe-8928-a40612cf502a"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Bahar",
     "slug": "bahar",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "scheme": "bahar",
     "userInterfaceStyle": "automatic",
@@ -81,7 +81,7 @@
     },
     "owner": "shunsei",
     "runtimeVersion": {
-      "policy": "appVersion"
+      "policy": "fingerprint"
     },
     "updates": {
       "url": "https://u.expo.dev/b6d34ce9-eea1-4afe-8928-a40612cf502a"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -57,7 +57,15 @@
         }
       ],
       "expo-secure-store",
-      "expo-notifications"
+      "expo-notifications",
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "organization": "bahar-app",
+          "project": "bahar-mobile"
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -8,20 +8,25 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "APP_VARIANT": "development"
+        "APP_VARIANT": "development",
+        "EXPO_PUBLIC_SENTRY_ENV": "local"
       },
       "channel": "development"
     },
     "preview": {
       "distribution": "internal",
       "env": {
-        "APP_VARIANT": "development"
+        "APP_VARIANT": "development",
+        "EXPO_PUBLIC_SENTRY_ENV": "preview"
       },
       "channel": "preview"
     },
     "production": {
       "autoIncrement": true,
-      "channel": "production"
+      "channel": "production",
+      "env": {
+        "EXPO_PUBLIC_SENTRY_ENV": "production"
+      }
     }
   },
   "submit": {

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,11 +1,12 @@
 // Learn more: https://docs.expo.dev/guides/monorepos/
-const { getDefaultConfig } = require("expo/metro-config");
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 const { withUniwindConfig } = require("uniwind/metro");
 
 const path = require("node:path");
 
-// First apply monorepo paths
-const baseConfig = withMonorepoPaths(getDefaultConfig(__dirname));
+// First apply monorepo paths. getSentryExpoConfig wraps Expo's getDefaultConfig
+// to assign Debug IDs to bundles + source maps for Sentry.
+const baseConfig = withMonorepoPaths(getSentryExpoConfig(__dirname));
 
 // Add Lingui extensions
 baseConfig.resolver.sourceExts = [

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,7 @@
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/drawer": "^7.5.10",
     "@react-navigation/native": "^7.1.22",
+    "@sentry/react-native": "~7.2.0",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.2.12",
     "@tanstack/react-query": "^5.82.2",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -22,8 +22,10 @@ import {
   DefaultTheme,
   ThemeProvider,
 } from "@react-navigation/native";
+import * as Sentry from "@sentry/react-native";
+import { isRunningInExpoGo } from "expo";
 import { useFonts } from "expo-font";
-import { Stack } from "expo-router";
+import { Stack, useNavigationContainerRef } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { setBackgroundColorAsync } from "expo-system-ui";
@@ -76,11 +78,37 @@ const setup = () => {
   setRootViewBackgroundColor();
 };
 
+const navigationIntegration = Sentry.reactNavigationIntegration({
+  enableTimeToInitialDisplay: !isRunningInExpoGo(),
+});
+
+Sentry.init({
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+  environment:
+    process.env.EXPO_PUBLIC_SENTRY_ENV ??
+    (process.env.NODE_ENV === "production" ? "production" : "local"),
+  enableLogs: true,
+  tracesSampleRate: 1.0,
+  // Sends user id/email (matching web/api) and enables route params on spans.
+  sendDefaultPii: true,
+  tracePropagationTargets: [
+    new RegExp(`^${process.env.EXPO_PUBLIC_API_BASE_URL}`),
+  ],
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1,
+  integrations: [
+    navigationIntegration,
+    Sentry.mobileReplayIntegration(),
+    Sentry.consoleLoggingIntegration({ levels: ["warn", "error"] }),
+  ],
+});
+
 setup();
 
-export default function RootLayout() {
+function RootLayout() {
   const { isPending, data: authData } = authClient.useSession();
   const colorScheme = useColorScheme();
+  const navigationRef = useNavigationContainerRef();
   const hasResolved = useRef(false);
   const [loaded] = useFonts({
     SpaceMono: require("@/assets/fonts/SpaceMono-Regular.ttf"),
@@ -92,6 +120,20 @@ export default function RootLayout() {
       SplashScreen.hideAsync();
     }
   }, [loaded, isPending]);
+
+  useEffect(() => {
+    if (navigationRef?.current) {
+      navigationIntegration.registerNavigationContainer(navigationRef);
+    }
+  }, [navigationRef]);
+
+  useEffect(() => {
+    if (authData?.user) {
+      Sentry.setUser({ id: authData.user.id, email: authData.user.email });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [authData?.user]);
 
   if (!loaded || (!hasResolved.current && isPending)) {
     return null;
@@ -215,3 +257,5 @@ function ThemeColorsInner({
 const DefaultComponent = (props: TransRenderProps) => {
   return <Text>{props.children}</Text>;
 };
+
+export default Sentry.wrap(RootLayout);

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -92,7 +92,9 @@ Sentry.init({
   environment: sentryEnv,
   enableLogs: true,
   tracesSampleRate: 1.0,
-  // Sends user id/email (matching web/api) and enables route params on spans.
+  // Attaches the user's IP and lets reactNavigationIntegration record route
+  // param values on spans (e.g. the word/deck id being edited). User id/email
+  // are set separately via Sentry.setUser, independent of this flag.
   sendDefaultPii: true,
   tracePropagationTargets: [
     new RegExp(`^${process.env.EXPO_PUBLIC_API_BASE_URL}`),

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -82,11 +82,14 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isRunningInExpoGo(),
 });
 
+const sentryEnv =
+  process.env.EXPO_PUBLIC_SENTRY_ENV ??
+  (process.env.NODE_ENV === "production" ? "production" : "local");
+const isLocalEnv = sentryEnv === "local";
+
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
-  environment:
-    process.env.EXPO_PUBLIC_SENTRY_ENV ??
-    (process.env.NODE_ENV === "production" ? "production" : "local"),
+  environment: sentryEnv,
   enableLogs: true,
   tracesSampleRate: 1.0,
   // Sends user id/email (matching web/api) and enables route params on spans.
@@ -94,11 +97,12 @@ Sentry.init({
   tracePropagationTargets: [
     new RegExp(`^${process.env.EXPO_PUBLIC_API_BASE_URL}`),
   ],
-  replaysOnErrorSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
+  // No session replay locally -- no value recording dev sessions.
+  replaysOnErrorSampleRate: isLocalEnv ? 0 : 1.0,
+  replaysSessionSampleRate: isLocalEnv ? 0 : 0.1,
   integrations: [
     navigationIntegration,
-    Sentry.mobileReplayIntegration(),
+    ...(isLocalEnv ? [] : [Sentry.mobileReplayIntegration()]),
     Sentry.consoleLoggingIntegration({ levels: ["warn", "error"] }),
   ],
 });

--- a/apps/mobile/src/hooks/useAppInit.ts
+++ b/apps/mobile/src/hooks/useAppInit.ts
@@ -4,6 +4,7 @@
  * Initializes the database and hydrates Orama search index on app startup.
  */
 
+import * as Sentry from "@sentry/react-native";
 import { useEffect, useState } from "react";
 import { initDb } from "@/lib/db";
 import { hydrateOramaDb } from "@/lib/search";
@@ -27,7 +28,13 @@ export const useAppInit = (): UseAppInitResult => {
       if (!dbResult.ok) {
         setState("error");
         setError(`Database error: ${dbResult.error.type}`);
-        console.error(dbResult.error);
+        Sentry.captureException(
+          new Error(dbResult.error.type, { cause: dbResult.error }),
+          {
+            fingerprint: ["db-init-error", dbResult.error.type],
+            contexts: { db_init: { type: dbResult.error.type } },
+          }
+        );
         return;
       }
 
@@ -35,7 +42,18 @@ export const useAppInit = (): UseAppInitResult => {
       if (!oramaResult.ok) {
         setState("error");
         setError(`Search error: ${oramaResult.error.type}`);
-        console.error(oramaResult.error);
+        Sentry.captureException(
+          new Error(oramaResult.error.type, { cause: oramaResult.error }),
+          {
+            fingerprint: ["orama-hydration-error", oramaResult.error.type],
+            contexts: {
+              orama_hydration: {
+                type: oramaResult.error.type,
+                reason: oramaResult.error.reason,
+              },
+            },
+          }
+        );
         return;
       }
 

--- a/apps/mobile/src/hooks/useSearch.ts
+++ b/apps/mobile/src/hooks/useSearch.ts
@@ -13,6 +13,7 @@ import {
 } from "@bahar/search/database";
 import type { DictionaryDocument } from "@bahar/search/schema";
 import type { InternalTypedDocument, Result, Results } from "@orama/orama";
+import * as Sentry from "@sentry/react-native";
 import { atom, useAtom, useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getOramaDb } from "@/lib/search";
@@ -171,7 +172,7 @@ export const useInfiniteSearch = (
       setSearchResultsMetadata({ ...metadata, searchTerm: params.term });
       setHasMore(newHits.length < metadata.count);
     } catch (error) {
-      console.error("Search error:", error);
+      Sentry.captureException(error, { tags: { operation: "search" } });
     } finally {
       setIsLoading(false);
     }
@@ -210,7 +211,7 @@ export const useInfiniteSearch = (
       setHits((prev) => [...(prev ?? []), ...newHits]);
       setHasMore(newOffset + newHits.length < metadata.count);
     } catch (error) {
-      console.error("Search error:", error);
+      Sentry.captureException(error, { tags: { operation: "search" } });
     }
   }, [
     offset,
@@ -240,7 +241,7 @@ export const useInfiniteSearch = (
       setSearchResultsMetadata({ ...metadata, searchTerm: params.term });
       setHasMore(newHits.length < metadata.count);
     } catch (error) {
-      console.error("Search error:", error);
+      Sentry.captureException(error, { tags: { operation: "search" } });
     }
   }, [search, params.term, whereFilter, sortBy, searchQueryLanguage]);
 

--- a/apps/mobile/src/lib/db/operations.ts
+++ b/apps/mobile/src/lib/db/operations.ts
@@ -13,6 +13,7 @@ import {
   makeProgressTable,
   makeSettingsTable,
 } from "@bahar/db-operations";
+import * as Sentry from "@sentry/react-native";
 import { api } from "../../utils/api";
 import { ensureDb } from ".";
 import { getDrizzleDb } from "./adapter";
@@ -32,12 +33,14 @@ const getDb = async () => {
 
 /**
  * Sends the clearBacklog review logs to the server. Fire-and-forget --
- * clearBacklog doesn't await this. Mirrors the single-revlog post in
- * FlashcardReview: mobile has no Sentry, so failures are logged to the console.
+ * clearBacklog doesn't await this. Failures are captured to Sentry, matching
+ * web's clearBacklog.revlogs tag.
  */
 const postClearBacklogRevlogs = (entries: ClearBacklogRevlogEntry[]) => {
   api.stats.revlogs.batch.post({ entries }).catch((err) => {
-    console.warn("[clearBacklog] Failed to post revlogs:", err);
+    Sentry.captureException(err, {
+      tags: { operation: "clearBacklog.revlogs" },
+    });
   });
 };
 

--- a/apps/mobile/src/lib/search/index.ts
+++ b/apps/mobile/src/lib/search/index.ts
@@ -24,6 +24,7 @@ import {
   updateDocument,
 } from "@bahar/search/database";
 import type { DictionaryDocument, DictionaryOrama } from "@bahar/search/schema";
+import * as Sentry from "@sentry/react-native";
 import { eq, max } from "drizzle-orm";
 import { z } from "zod";
 import { ensureDb } from "../db";
@@ -172,7 +173,10 @@ export const rehydrateOramaDb = async (): Promise<void> => {
     oramaDb = newOramaDb;
     isHydrated = true;
   } catch (error) {
-    console.error("[orama] Rehydration failed:", error);
+    Sentry.captureException(error, {
+      fingerprint: ["orama-rehydration-error"],
+      contexts: { orama_hydration: { stage: "rehydration_failed" } },
+    });
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@react-navigation/native':
         specifier: ^7.1.22
         version: 7.1.22(react-native@0.81.5)(react@19.1.0)
+      '@sentry/react-native':
+        specifier: ~7.2.0
+        version: 7.2.0(expo@54.0.33)(react-native@0.81.5)(react@19.1.0)
       '@shopify/flash-list':
         specifier: 2.0.2
         version: 2.0.2(@babel/runtime@7.29.2)(react-native@0.81.5)(react@19.1.0)
@@ -11991,6 +11994,13 @@ packages:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
 
+  /@sentry-internal/browser-utils@10.12.0:
+    resolution: {integrity: sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry/core': 10.12.0
+    dev: false
+
   /@sentry-internal/browser-utils@10.25.0:
     resolution: {integrity: sha512-wzg1ITZxrRtQouHPCgpt3tl1GiNAWFVy2RYK2KstFEhpYBAOUn9BAdP7KU9UyHBFKqbAvV4oGtAT8H2/Y4+leA==}
     engines: {node: '>=18'}
@@ -11998,11 +12008,26 @@ packages:
       '@sentry/core': 10.25.0
     dev: false
 
+  /@sentry-internal/feedback@10.12.0:
+    resolution: {integrity: sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry/core': 10.12.0
+    dev: false
+
   /@sentry-internal/feedback@10.25.0:
     resolution: {integrity: sha512-qlbT4tOd+WRyKpLdsbi26rkynGBoVabnY8/9rFnTxZ0WIUG5EFhJFqEeRLMyv+uk0uRFF3H0I9+u+qP/BKxIcQ==}
     engines: {node: '>=18'}
     dependencies:
       '@sentry/core': 10.25.0
+    dev: false
+
+  /@sentry-internal/replay-canvas@10.12.0:
+    resolution: {integrity: sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry-internal/replay': 10.12.0
+      '@sentry/core': 10.12.0
     dev: false
 
   /@sentry-internal/replay-canvas@10.25.0:
@@ -12013,6 +12038,14 @@ packages:
       '@sentry/core': 10.25.0
     dev: false
 
+  /@sentry-internal/replay@10.12.0:
+    resolution: {integrity: sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry-internal/browser-utils': 10.12.0
+      '@sentry/core': 10.12.0
+    dev: false
+
   /@sentry-internal/replay@10.25.0:
     resolution: {integrity: sha512-V/kKQn9T46HBTiP0bIThmpVr94K4vXwYM3/EHVpGSq4P9RynX06cgps8GLHq94+A0kX/DbK9igEMZmIuzS1q3A==}
     engines: {node: '>=18'}
@@ -12021,9 +12054,25 @@ packages:
       '@sentry/core': 10.25.0
     dev: false
 
+  /@sentry/babel-plugin-component-annotate@4.3.0:
+    resolution: {integrity: sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==}
+    engines: {node: '>= 14'}
+    dev: false
+
   /@sentry/babel-plugin-component-annotate@4.6.0:
     resolution: {integrity: sha512-3soTX50JPQQ51FSbb4qvNBf4z/yP7jTdn43vMTp9E4IxvJ9HKJR7OEuKkCMszrZmWsVABXl02msqO7QisePdiQ==}
     engines: {node: '>= 14'}
+    dev: false
+
+  /@sentry/browser@10.12.0:
+    resolution: {integrity: sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry-internal/browser-utils': 10.12.0
+      '@sentry-internal/feedback': 10.12.0
+      '@sentry-internal/replay': 10.12.0
+      '@sentry-internal/replay-canvas': 10.12.0
+      '@sentry/core': 10.12.0
     dev: false
 
   /@sentry/browser@10.25.0:
@@ -12064,6 +12113,14 @@ packages:
       - supports-color
     dev: false
 
+  /@sentry/cli-darwin@2.55.0:
+    resolution: {integrity: sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@sentry/cli-darwin@2.58.2:
     resolution: {integrity: sha512-MArsb3zLhA2/cbd4rTm09SmTpnEuZCoZOpuZYkrpDw1qzBVJmRFA1W1hGAQ9puzBIk/ubY3EUhhzuU3zN2uD6w==}
     engines: {node: '>=10'}
@@ -12072,10 +12129,28 @@ packages:
     dev: false
     optional: true
 
+  /@sentry/cli-linux-arm64@2.55.0:
+    resolution: {integrity: sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@sentry/cli-linux-arm64@2.58.2:
     resolution: {integrity: sha512-ay3OeObnbbPrt45cjeUyQjsx5ain1laj1tRszWj37NkKu55NZSp4QCg1gGBZ0gBGhckI9nInEsmKtix00alw2g==}
     engines: {node: '>=10'}
     cpu: [arm64]
+    os: [linux, freebsd, android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@sentry/cli-linux-arm@2.55.0:
+    resolution: {integrity: sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
     os: [linux, freebsd, android]
     requiresBuild: true
     dev: false
@@ -12090,10 +12165,28 @@ packages:
     dev: false
     optional: true
 
+  /@sentry/cli-linux-i686@2.55.0:
+    resolution: {integrity: sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@sentry/cli-linux-i686@2.58.2:
     resolution: {integrity: sha512-CN9p0nfDFsAT1tTGBbzOUGkIllwS3hygOUyTK7LIm9z+UHw5uNgNVqdM/3Vg+02ymjkjISNB3/+mqEM5osGXdA==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@sentry/cli-linux-x64@2.55.0:
+    resolution: {integrity: sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
     os: [linux, freebsd, android]
     requiresBuild: true
     dev: false
@@ -12108,10 +12201,28 @@ packages:
     dev: false
     optional: true
 
+  /@sentry/cli-win32-arm64@2.55.0:
+    resolution: {integrity: sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@sentry/cli-win32-arm64@2.58.2:
     resolution: {integrity: sha512-+cl3x2HPVMpoSVGVM1IDWlAEREZrrVQj4xBb0TRKII7g3hUxRsAIcsrr7+tSkie++0FuH4go/b5fGAv51OEF3w==}
     engines: {node: '>=10'}
     cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@sentry/cli-win32-i686@2.55.0:
+    resolution: {integrity: sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
     os: [win32]
     requiresBuild: true
     dev: false
@@ -12126,6 +12237,15 @@ packages:
     dev: false
     optional: true
 
+  /@sentry/cli-win32-x64@2.55.0:
+    resolution: {integrity: sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@sentry/cli-win32-x64@2.58.2:
     resolution: {integrity: sha512-2NAFs9UxVbRztQbgJSP5i8TB9eJQ7xraciwj/93djrSMHSEbJ0vC47TME0iifgvhlHMs5vqETOKJtfbbpQAQFA==}
     engines: {node: '>=10'}
@@ -12134,6 +12254,31 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@sentry/cli@2.55.0:
+    resolution: {integrity: sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.55.0
+      '@sentry/cli-linux-arm': 2.55.0
+      '@sentry/cli-linux-arm64': 2.55.0
+      '@sentry/cli-linux-i686': 2.55.0
+      '@sentry/cli-linux-x64': 2.55.0
+      '@sentry/cli-win32-arm64': 2.55.0
+      '@sentry/cli-win32-i686': 2.55.0
+      '@sentry/cli-win32-x64': 2.55.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /@sentry/cli@2.58.2:
     resolution: {integrity: sha512-U4u62V4vaTWF+o40Mih8aOpQKqKUbZQt9A3LorIJwaE3tO3XFLRI70eWtW2se1Qmy0RZ74zB14nYcFNFl2t4Rw==}
@@ -12158,6 +12303,11 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: false
+
+  /@sentry/core@10.12.0:
+    resolution: {integrity: sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==}
+    engines: {node: '>=18'}
     dev: false
 
   /@sentry/core@10.25.0:
@@ -12258,6 +12408,43 @@ packages:
       '@sentry/core': 10.32.1
     dev: false
 
+  /@sentry/react-native@7.2.0(expo@54.0.33)(react-native@0.81.5)(react@19.1.0):
+    resolution: {integrity: sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: 19.1.0
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 4.3.0
+      '@sentry/browser': 10.12.0
+      '@sentry/cli': 2.55.0
+      '@sentry/core': 10.12.0
+      '@sentry/react': 10.12.0(react@19.1.0)
+      '@sentry/types': 10.12.0
+      expo: 54.0.33(@babel/core@7.26.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.2)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.26.0)(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@sentry/react@10.12.0(react@19.1.0):
+    resolution: {integrity: sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: 19.1.0
+    dependencies:
+      '@sentry/browser': 10.12.0
+      '@sentry/core': 10.12.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.1.0
+    dev: false
+
   /@sentry/react@10.25.0(react@19.1.0):
     resolution: {integrity: sha512-LBQHgyPAFzuy99mEJF8ZF2AOxxJiGAmtu10eQhglhFgfJsU7JJVsee0h+vTSmvHMDtFrIwhZi3i1X5snZ/kzoA==}
     engines: {node: '>=18'}
@@ -12268,6 +12455,13 @@ packages:
       '@sentry/core': 10.25.0
       hoist-non-react-statics: 3.3.2
       react: 19.1.0
+    dev: false
+
+  /@sentry/types@10.12.0:
+    resolution: {integrity: sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sentry/core': 10.12.0
     dev: false
 
   /@sentry/vite-plugin@4.6.0:


### PR DESCRIPTION
Wires Sentry into the mobile app so we can debug production issues. Uses `@sentry/react-native@7.2.0` (the version Expo SDK 54 pins) and follows the same conventions as web/api.

## What it captures
- **Errors/exceptions** — global JS errors via `Sentry.wrap`, plus explicit `captureException` at known failure points (db init, search hydration/rehydration, search queries, revlog batch post) with the same `tags`/`fingerprint`/`contexts` shape web uses.
- **Performance tracing** — `tracesSampleRate: 1.0` + expo-router navigation instrumentation. `tracePropagationTargets` points at the API base URL, so a mobile request and its `bahar-api` spans share one `trace_id` (same automatic frontend↔backend linking web already has).
- **Structured logging** — `enableLogs: true` and `Sentry.logger.*`. Console capture is limited to `warn`+`error` (RN captures all levels by default) to match web.
- **User context** — `setUser({ id, email })` on session, cleared on sign-out.
- **Session Replay** — `mobileReplayIntegration` (10% of sessions, 100% on error), matching web's rates.

## Files
- `metro.config.js` — `getSentryExpoConfig` for source-map Debug IDs, composed with the existing Uniwind/monorepo/Lingui wrappers
- `app.json` — `@sentry/react-native/expo` plugin (org `bahar-app`, project `bahar-mobile`)
- `eas.json` — `EXPO_PUBLIC_SENTRY_ENV` per build profile (production previously had no `env` block)
- `_layout.tsx` — `Sentry.init`, navigation instrumentation, `setUser`, `Sentry.wrap`
- capture sites: `useAppInit`, `useSearch`, `lib/search`, `lib/db/operations`

## Verification
`tsc` clean (no new source errors), biome clean, Metro config loads, both plugin entrypoints resolve. Not run: a native/EAS build — needs a simulator/device.

## Ops steps required before this works ⚠️
This is inert until these are done — the SDK no-ops without a DSN.

1. **Create the Sentry project** `bahar-mobile` under org `bahar-app`.
2. **Set `EXPO_PUBLIC_SENTRY_DSN`** (the public DSN from that project) as an EAS environment variable, and in `.env.local` for local builds.
3. **Set `SENTRY_AUTH_TOKEN`** as an EAS secret (and `.env.local`) so the config plugin can upload source maps during native builds. Do not commit it.

`EXPO_PUBLIC_SENTRY_ENV` is already wired per EAS profile (`local` / `preview` / `production`); it falls back to `local` on plain `expo start`.