### PR TITLE
fix(web): bump sync-wasm to 0.6.1 so migration subqueries parse

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
     "@tanstack/react-query-devtools": "^5.82.2",
     "@tanstack/react-router": "^1.119.0",
     "@tanstack/zod-adapter": "^1.150.0",
-    "@tursodatabase/sync-wasm": "^0.3.2",
+    "@tursodatabase/sync-wasm": "^0.6.1",
     "@uidotdev/usehooks": "^2.4.1",
     "better-auth": "1.4.19",
     "date-fns": "^3.6.0",

--- a/apps/web/src/lib/db/index.ts
+++ b/apps/web/src/lib/db/index.ts
@@ -57,7 +57,7 @@ export const buildDrizzleDb = (getDb: () => Database | null) =>
       const db = getDb();
       if (!db) return { rows: [] };
 
-      const stmt = db.prepare(sql);
+      const stmt = await db.prepare(sql);
 
       if (method === "run") {
         await stmt.run(params);
@@ -391,16 +391,10 @@ const applyRequiredMigrations = async () => {
     if (!execResult.ok) {
       await tryCatch(
         () =>
-          db!
-            .prepare(
-              "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)"
-            )
-            .run([
-              migration.version,
-              migration.description,
-              nowTimestampMs,
-              "failed",
-            ]),
+          db!.run(
+            "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)",
+            [migration.version, migration.description, nowTimestampMs, "failed"]
+          ),
         (error) => {
           Sentry.logger.error("Failed to log failed migration", {
             migrationVersion: migration.version,
@@ -415,16 +409,10 @@ const applyRequiredMigrations = async () => {
 
     await tryCatch(
       () =>
-        db!
-          .prepare(
-            "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)"
-          )
-          .run([
-            migration.version,
-            migration.description,
-            nowTimestampMs,
-            "applied",
-          ]),
+        db!.run(
+          "INSERT INTO migrations (version, description, applied_at_ms, status) VALUES (?, ?, ?, ?)",
+          [migration.version, migration.description, nowTimestampMs, "applied"]
+        ),
       (error) => {
         Sentry.logger.error("Failed to log successful migration", {
           migrationVersion: migration.version,
@@ -443,11 +431,9 @@ const getLocalAppliedMigrations = async () => {
 
   const tableExists = await tryCatch(
     async () => {
-      const result = await db!
-        .prepare(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name='migrations';"
-        )
-        .get();
+      const result = await db!.get(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='migrations';"
+      );
       return !!result;
     },
     () => ({ type: "check_migration_table_exists_query_failed" })
@@ -458,9 +444,9 @@ const getLocalAppliedMigrations = async () => {
 
   return tryCatch(
     async () => {
-      const rows: SelectMigration[] = await db!
-        .prepare("SELECT * FROM migrations;")
-        .all();
+      const rows: SelectMigration[] = await db!.all(
+        "SELECT * FROM migrations;"
+      );
       return rows;
     },
     () => ({ type: "local_migrations_query_failed" })

--- a/apps/web/src/lib/db/test/create-test-db.browser.test.ts
+++ b/apps/web/src/lib/db/test/create-test-db.browser.test.ts
@@ -18,11 +18,9 @@ describe("createTestDb", () => {
   it("applies migrations so the schema tables exist", async () => {
     testDb = await createTestDb();
 
-    const tables = await testDb.db
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
-      )
-      .all();
+    const tables = await testDb.db.all(
+      "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+    );
 
     const tableNames = tables.map((row: { name: string }) => row.name);
 
@@ -39,13 +37,14 @@ describe("createTestDb", () => {
   it("runs real writes and reads through the raw db handle", async () => {
     testDb = await createTestDb();
 
-    await testDb.db
-      .prepare("INSERT INTO decks (id, name, filters) VALUES (?, ?, ?);")
-      .run(["deck-1", "Test Deck", null]);
+    await testDb.db.run(
+      "INSERT INTO decks (id, name, filters) VALUES (?, ?, ?);",
+      ["deck-1", "Test Deck", null]
+    );
 
-    const deck = await testDb.db
-      .prepare("SELECT * FROM decks WHERE id = ?;")
-      .get(["deck-1"]);
+    const deck = await testDb.db.get("SELECT * FROM decks WHERE id = ?;", [
+      "deck-1",
+    ]);
 
     expect(deck).toEqual({ id: "deck-1", name: "Test Deck", filters: null });
   });
@@ -59,13 +58,16 @@ describe("createTestDb", () => {
       create_reverse_by_default: false,
     });
 
-    const rows = await testDb.db.prepare("SELECT * FROM settings;").all();
+    const rows = await testDb.db.all("SELECT * FROM settings;");
 
+    // Raw SELECT * returns the real SQL column name (`show_reverse_flashcards`),
+    // not the Drizzle field alias (`create_reverse_by_default`) used on insert
+    // above. The column was repurposed via alias, never renamed (BAH-161).
     expect(rows).toEqual([
       {
         id: "settings-1",
         show_antonyms_in_flashcard: "hidden",
-        create_reverse_by_default: 0,
+        show_reverse_flashcards: 0,
       },
     ]);
   });
@@ -122,14 +124,15 @@ describe("createTestDb", () => {
   it("gives each createTestDb() call an isolated database", async () => {
     testDb = await createTestDb();
 
-    await testDb.db
-      .prepare("INSERT INTO decks (id, name, filters) VALUES (?, ?, ?);")
-      .run(["deck-1", "Test Deck", null]);
+    await testDb.db.run(
+      "INSERT INTO decks (id, name, filters) VALUES (?, ?, ?);",
+      ["deck-1", "Test Deck", null]
+    );
 
     const otherDb = await createTestDb();
 
     try {
-      const decks = await otherDb.db.prepare("SELECT * FROM decks;").all();
+      const decks = await otherDb.db.all("SELECT * FROM decks;");
       expect(decks).toEqual([]);
     } finally {
       await otherDb.close();

--- a/apps/web/src/lib/search/index.ts
+++ b/apps/web/src/lib/search/index.ts
@@ -106,9 +106,10 @@ export const hydrateOramaDb = async () => {
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const results: RawDictionaryEntry[] = await db
-        .prepare("SELECT * FROM dictionary_entries LIMIT ? OFFSET ?")
-        .all([BATCH_SIZE, offset]);
+      const results: RawDictionaryEntry[] = await db.all(
+        "SELECT * FROM dictionary_entries LIMIT ? OFFSET ?",
+        [BATCH_SIZE, offset]
+      );
 
       if (results.length === 0) break;
 
@@ -299,9 +300,10 @@ export const rehydrateOramaDb = async () => {
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const results: RawDictionaryEntry[] = await db
-        .prepare("SELECT * FROM dictionary_entries LIMIT ? OFFSET ?")
-        .all([BATCH_SIZE, offset]);
+      const results: RawDictionaryEntry[] = await db.all(
+        "SELECT * FROM dictionary_entries LIMIT ? OFFSET ?",
+        [BATCH_SIZE, offset]
+      );
 
       if (results.length === 0) break;
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -13,13 +13,17 @@ export const router = createRouter({
   },
 });
 
+const isLocalEnv = import.meta.env.VITE_SENTRY_ENV === "local";
+
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: import.meta.env.VITE_SENTRY_ENV,
   enableLogs: true,
   integrations: [
     Sentry.tanstackRouterBrowserTracingIntegration(router),
-    Sentry.replayIntegration(),
+    // Skip session replay locally -- no value in recording dev sessions, and it
+    // avoids loading the replay bundle in development.
+    ...(isLocalEnv ? [] : [Sentry.replayIntegration()]),
     Sentry.consoleLoggingIntegration({ levels: ["warn", "error"] }),
   ],
 
@@ -38,8 +42,8 @@ Sentry.init({
   // plus for 100% of sessions with an error
   // Learn more at
   // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: isLocalEnv ? 0 : 0.1,
+  replaysOnErrorSampleRate: isLocalEnv ? 0 : 1.0,
 });
 
 // Register the router instance for type safety

--- a/apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx
+++ b/apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx
@@ -152,19 +152,18 @@ const Settings = () => {
 
         const db = await ensureDb();
 
-        const entries: RawDictionaryEntry[] = await db
-          .prepare("SELECT * FROM dictionary_entries")
-          .all();
+        const entries: RawDictionaryEntry[] = await db.all(
+          "SELECT * FROM dictionary_entries"
+        );
 
         const exportData: unknown[] = [];
 
         let skippedCount = 0;
         for (const entry of entries) {
-          const flashcards: SelectFlashcard[] = await db
-            .prepare(
-              "SELECT * FROM flashcards WHERE dictionary_entry_id = ? ORDER BY direction"
-            )
-            .all([entry.id]);
+          const flashcards: SelectFlashcard[] = await db.all(
+            "SELECT * FROM flashcards WHERE dictionary_entry_id = ? ORDER BY direction",
+            [entry.id]
+          );
 
           const result = transformForExport({
             entry,
@@ -433,13 +432,9 @@ const Settings = () => {
                           const { dictEntry, flashcards } =
                             createImportStatements(word, version);
 
-                          await db.prepare(dictEntry.sql).run(dictEntry.args);
-                          await db
-                            .prepare(flashcards[0].sql)
-                            .run(flashcards[0].args);
-                          await db
-                            .prepare(flashcards[1].sql)
-                            .run(flashcards[1].args);
+                          await db.run(dictEntry.sql, dictEntry.args);
+                          await db.run(flashcards[0].sql, flashcards[0].args);
+                          await db.run(flashcards[1].sql, flashcards[1].args);
                         }
                       }
                     );

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
         test: {
           name: "node",
           environment: "node",
-          exclude: ["**/node_modules/**", "**/*.browser.test.ts"],
+          // Exclude Playwright e2e specs -- they use @playwright/test's `test()`,
+          // which throws if collected by vitest's runner.
+          exclude: ["**/node_modules/**", "**/*.browser.test.ts", "**/e2e/**"],
         },
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,8 +593,8 @@ importers:
         specifier: ^1.150.0
         version: 1.150.0(@tanstack/react-router@1.120.13)(zod@4.3.6)
       '@tursodatabase/sync-wasm':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.6.1
+        version: 0.6.1
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.1.0)(react@19.1.0)
@@ -3880,7 +3880,7 @@ packages:
     peerDependencies:
       elysia: '>=1.4.19'
     dependencies:
-      elysia: 1.4.27(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.2)
+      elysia: 1.4.27(@sinclair/typebox@0.34.49)(@types/bun@1.3.11)(exact-mirror@1.0.0)(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.8.3)
     dev: false
 
   /@emmetio/abbreviation@2.3.3:
@@ -3915,9 +3915,25 @@ packages:
 
   /@emnapi/core@1.5.0:
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
+    requiresBuild: true
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
+    dev: true
+    optional: true
+
+  /@emnapi/core@1.8.1:
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    dev: false
+
+  /@emnapi/runtime@1.8.1:
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
 
   /@emnapi/runtime@1.9.2:
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -7086,7 +7102,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@lingui/babel-plugin-lingui-macro@5.3.2(babel-plugin-macros@3.1.0)(typescript@5.9.2):
     resolution: {integrity: sha512-NdXrq8aZlPjN4jeA/LkSLNyx5vPGmrW+r2ywMNQDPQPVP28Hq8c3hF9SQc1t7hwBorGQ3qzIQ7i2Vm6Y8PnjQw==}
@@ -7215,7 +7230,6 @@ packages:
       jiti: 1.21.7
     transitivePeerDependencies:
       - typescript
-    dev: true
 
   /@lingui/conf@5.3.2(typescript@5.9.2):
     resolution: {integrity: sha512-c0Dfovr9BLuwAnY5GADxKcwBUQdVl0Jo/JUa3cumIXFhHzZGb78kfhCHjWWQdX8+WQD8qzSl/YkVDbxhcQJGmg==}
@@ -7259,7 +7273,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.26.7
-      '@lingui/babel-plugin-lingui-macro': 5.3.2(babel-plugin-macros@3.1.0)(typescript@5.9.2)
+      '@lingui/babel-plugin-lingui-macro': 5.3.2(babel-plugin-macros@3.1.0)(typescript@5.8.3)
       '@lingui/message-utils': 5.3.2
       babel-plugin-macros: 3.1.0
       unraw: 3.0.0
@@ -7483,7 +7497,7 @@ packages:
   /@napi-rs/wasm-runtime@1.0.7:
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
     dependencies:
-      '@emnapi/core': 1.5.0
+      '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     dev: false
@@ -13459,36 +13473,25 @@ packages:
       whatwg-fetch: 3.6.20
     dev: false
 
-  /@tursodatabase/database-common@0.3.2:
-    resolution: {integrity: sha512-CPkPuvDMUS6mKIdAwpCbfU7g6U81/mSfCcMDXZ6Bt1dA8DJyOgTZRf80MDaWTKLQ+0mjkmQ0cZPb9zD/R41Vkg==}
-    dev: false
-
   /@tursodatabase/database-common@0.6.1:
     resolution: {integrity: sha512-fkmkhgSUDg3MXkcziTG9Ime3AY5+YvvDN7VvUDEMNV7MP+XgwE/i5tU6eQP1EKa/zDkdSYPq8gPcmROmKmKL8Q==}
-    dev: true
 
-  /@tursodatabase/database-wasm-common@0.3.2:
-    resolution: {integrity: sha512-ljpo471synyHzse8unmD+d2azo32A9nbiONS43URWlvEhSOpnkhuE5MjNgP9m468f8VyEU2qjvbgqxH8Ko9Q6A==}
+  /@tursodatabase/database-wasm-common@0.6.1:
+    resolution: {integrity: sha512-lZdZ7b8YSF0RKN0U1ZTtPNaf9zR6k+8tGpN3eWN8vtCXWIPVEw4ydhZodSuFK+EkoPekVHcW/yAYHvGu2KQLug==}
     dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
       '@napi-rs/wasm-runtime': 1.0.7
     dev: false
 
   /@tursodatabase/serverless@0.2.4:
     resolution: {integrity: sha512-kqf3FINvTGx8N1iH/4e1Dkbr/om5q9qitshzvljtQXwZFQIsVP/mDE76mGg9U2dg/ElOZKFKtT1VXDgd39Dr1w==}
-    dev: true
-
-  /@tursodatabase/sync-common@0.3.2:
-    resolution: {integrity: sha512-cUQEHUu79sbPNVi2bba2jTDz3GIN/HOf5bLkdMNqX5lXy78/H/HrnkflZ1QbjgutVLyIkz5jkd0PgvzojFwh+A==}
-    dependencies:
-      '@tursodatabase/database-common': 0.3.2
-    dev: false
 
   /@tursodatabase/sync-common@0.6.1:
     resolution: {integrity: sha512-QjImpfwGomXRPmr7+KQUxN1RHslOCY77ElHgmAdpDy0IAqp4WDO12waPpzV45hxoVb6tlmuArFEDdBGdiq9npQ==}
     dependencies:
       '@tursodatabase/database-common': 0.6.1
       '@tursodatabase/serverless': 0.2.4
-    dev: true
 
   /@tursodatabase/sync-darwin-arm64@0.6.1:
     resolution: {integrity: sha512-OneZUhTPTPkf048nu2rr39YLM2+CnAcY9oJUsAJvUc2ClLUIvFQtHSgTP7L13LtaLXLjR6Htzy77jKz+0hF4Tw==}
@@ -13526,12 +13529,12 @@ packages:
       react-native: 0.81.5(@babel/core@7.26.0)(@types/react@19.1.17)(react@19.1.0)
     dev: false
 
-  /@tursodatabase/sync-wasm@0.3.2:
-    resolution: {integrity: sha512-R1JkmyjcJGtTz59sTWvyFWHvYa0Xiqkcs66EoVo99E4S7lXYGbwVSuulI7GY23T2sI3E895hOiKjSLoWPOkdnw==}
+  /@tursodatabase/sync-wasm@0.6.1:
+    resolution: {integrity: sha512-VPkpJYIJzutTjkmkwZe8v313GdMP+brXRoMGPC3pPptHxW5vn9WZ7wWp4vfEc00O4vMUSeOFpc9WbENnHzvdiA==}
     dependencies:
-      '@tursodatabase/database-common': 0.3.2
-      '@tursodatabase/database-wasm-common': 0.3.2
-      '@tursodatabase/sync-common': 0.3.2
+      '@tursodatabase/database-common': 0.6.1
+      '@tursodatabase/database-wasm-common': 0.6.1
+      '@tursodatabase/sync-common': 0.6.1
     dev: false
 
   /@tursodatabase/sync-win32-x64-msvc@0.6.1:
@@ -16119,7 +16122,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.8.3
-    dev: true
 
   /cosmiconfig@8.3.6(typescript@5.9.2):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -17001,31 +17003,6 @@ packages:
       memoirist: 0.4.0
       openapi-types: 12.1.3
       typescript: 5.8.3
-    dev: false
-
-  /elysia@1.4.27(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.2):
-    resolution: {integrity: sha512-2UlmNEjPJVA/WZVPYKy+KdsrfFwwNlqSBW1lHz6i2AHc75k7gV4Rhm01kFeotH7PDiHIX2G8X3KnRPc33SGVIg==}
-    peerDependencies:
-      '@sinclair/typebox': '>= 0.34.0 < 1'
-      '@types/bun': '>= 1.2.0'
-      exact-mirror: '>= 0.0.9'
-      file-type: '>= 20.0.0'
-      openapi-types: '>= 12.0.0'
-      typescript: '>= 5.0.0'
-    peerDependenciesMeta:
-      '@types/bun':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@sinclair/typebox': 0.34.49
-      cookie: 1.1.1
-      exact-mirror: 1.0.0
-      fast-decode-uri-component: 1.0.1
-      file-type: 22.0.0
-      memoirist: 0.4.0
-      openapi-types: 12.1.3
-      typescript: 5.9.2
     dev: false
 
   /emittery@0.13.1:


### PR DESCRIPTION
## Incident

The BAH-161 reverse-cleanup migration (`0004`) failed on **web** for every user with:

```
failed to consume stmt: Parse error: Subquery is not supported in this position
```

Root cause: the pinned `@tursodatabase/sync-wasm@0.3.2` (turso/Limbo, the client engine) has **no subquery support in `DELETE`/`UPDATE` `WHERE`** — scalar subqueries, `EXISTS`, `IN (SELECT)`, CTEs, temp tables, and `UPDATE … FROM` were all rejected (verified with a probe against the real engine). Mobile was already on `sync-react-native@0.6.1` and unaffected — which is why only web failed. The cloud DB (Drizzle Studio / libsql) runs the query fine; the migration executes **client-side** on sync-wasm, so it has to parse there.

## Fix

Bump web `sync-wasm` `0.3.2 → 0.6.1` (matching mobile). On 0.6.1 the `0004` migration parses and applies correctly — verified across all settings states (OFF → delete reverse rows, ON → keep, no settings row → delete) against the real engine.

0.6.1 makes `Database.prepare()` **async** (`Promise<Statement>`), a breaking change. Migrated every synchronous `prepare()` call:
- drizzle-proxy driver now `await`s `prepare`
- migration recorder/applier reads, settings export/import, and search switched to the single-await `db.run/get/all` convenience methods

## Also
- Exclude Playwright `e2e/**` from the vitest **node** project (they threw "Playwright Test did not expect `test()` to be called here").
- Fix a stale browser-test assertion: raw `SELECT *` returns the real column `show_reverse_flashcards`, not the drizzle alias `create_reverse_by_default`.
- Disable Sentry session replay when `VITE_SENTRY_ENV=local`.

## Verification
- Browser tests (real sync-wasm): **7/7**
- Node tests: **7/7**, `tsc` clean, lint clean

## ⚠️ Before merge/deploy
Browser tests use an **in-memory** DB, so **OPFS on-disk format + sync-protocol compat** between 0.3.2 and 0.6.1 is NOT covered here. Do a real dev login on 0.6.1 and confirm an existing OPFS DB opens + syncs round-trip (no re-download/conflict) before shipping to prod.

Relates to BAH-161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)