### PR TITLE
fix(web): repair change logs poisoned by stale bundles, and re-register the service worker

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,3 +1,18 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
+
+# Pages defaults sw.js to max-age=14400 like any other asset. Browsers bypass
+# their own HTTP cache when checking for a new worker, so that mostly doesn't
+# matter -- but an intermediary proxy honouring it can stall a deploy from
+# reaching a client for hours. The service worker is what pulls clients onto new
+# code, so it should never be served stale.
+/sw.js
+  Cache-Control: no-cache
+
+# Everything under /assets is content-hashed, so a changed file is a changed
+# URL and the old one is never requested again. Pages defaults these to four
+# hours, which makes repeat visitors revalidate every chunk several times a day
+# for nothing -- including the 11 MB wasm.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/apps/web/src/lib/db/index.ts
+++ b/apps/web/src/lib/db/index.ts
@@ -40,6 +40,71 @@ const describeError = (error: unknown) => ({
 });
 
 /**
+ * A stale bundle running an older sync-wasm writes change-log entries using the
+ * older column layout. Every value lands one column off, so `table_name` (text)
+ * ends up in `change_type` -- and SQLite stores it as text regardless of the
+ * column's declared INTEGER type, so the write succeeds silently. The current
+ * engine then can't parse the entry, and since it can never be drained, every
+ * later push fails on it too. Sync stays broken across releases until the entry
+ * is removed.
+ *
+ * The class covers more than that corruption (a malformed payload reports the
+ * same way), so a match only means "worth attempting a repair", not "repairable".
+ */
+const POISONED_CHANGE_LOG_ERROR = "database tape error";
+
+const isPoisonedChangeLogError = (reason: string) =>
+  reason.includes(POISONED_CHANGE_LOG_ERROR);
+
+/**
+ * Removes only the malformed entries, so well-formed pending changes queued
+ * behind them still push. `typeof()` reports a value's real storage class rather
+ * than the column's declared type, which identifies exactly the rows written
+ * under the wrong layout.
+ *
+ * Writes made during the stale-bundle session go with those entries, and
+ * deletions from it reappear on the next pull. Both are bounded to that one
+ * session. No user table is touched.
+ *
+ * Returns whether anything was removed, so the caller only retries a sync that
+ * has a reason to now succeed.
+ */
+const repairPoisonedChangeLog = async () => {
+  if (!db) return false;
+
+  const result = await tryCatch(
+    async () => {
+      const before: { n: number } | undefined = await db!.get(
+        "SELECT COUNT(*) AS n FROM turso_cdc WHERE typeof(change_type) != 'integer';"
+      );
+      const poisoned = before?.n ?? 0;
+      if (poisoned === 0) return 0;
+
+      await db!.run(
+        "DELETE FROM turso_cdc WHERE typeof(change_type) != 'integer';"
+      );
+      return poisoned;
+    },
+    (error) => ({
+      type: "change_log_repair_failed",
+      ...describeError(error),
+    })
+  );
+
+  if (!result.ok) {
+    Sentry.captureException(
+      new Error(result.error.type, { cause: result.error }),
+      { fingerprint: ["db-init-error", result.error.type] }
+    );
+    return false;
+  }
+
+  Sentry.logger.info("Repaired poisoned change log", { removed: result.value });
+
+  return result.value > 0;
+};
+
+/**
  * Records the browser storage/runtime environment as Sentry context. This is the
  * layer with the least visibility for local-DB failures -- OPFS support, storage
  * quota/pressure, install mode (PWA standalone vs browser tab), cross-origin
@@ -52,9 +117,18 @@ const setStorageEnvContext = async () => {
     window.matchMedia("(display-mode: standalone)").matches ||
     (navigator as { standalone?: boolean }).standalone === true;
 
+  // Without this the origin is "best-effort" storage, which the browser may
+  // evict wholesale under device storage pressure -- taking the OPFS db with
+  // it. Writes that haven't synced yet exist nowhere else, so that loss is
+  // permanent. Chrome grants this silently for installed PWAs and high
+  // engagement rather than prompting; a denial just leaves us where we were.
+  const persistGranted =
+    (await navigator.storage?.persist?.().catch(() => null)) ?? null;
+
   Sentry.setContext("storage_env", {
     displayMode: standalone ? "standalone" : "browser",
     opfsSupported: typeof navigator.storage?.getDirectory === "function",
+    persistGranted,
     persisted:
       (await navigator.storage?.persisted?.().catch(() => null)) ?? null,
     quota: estimate?.quota ?? null,
@@ -390,7 +464,7 @@ const _initDbInternal = async () => {
     return migrationResult;
   }
 
-  const syncResult = await tryCatch(
+  let syncResult = await tryCatch(
     async () => {
       await db!.pull();
       await db!.push();
@@ -400,6 +474,27 @@ const _initDbInternal = async () => {
       ...describeError(error),
     })
   );
+
+  if (!syncResult.ok && isPoisonedChangeLogError(syncResult.error.reason)) {
+    const repaired = await repairPoisonedChangeLog();
+
+    if (repaired) {
+      syncResult = await tryCatch(
+        async () => {
+          await db!.pull();
+          await db!.push();
+        },
+        (error) => ({
+          type: "turso_remote_sync_failed",
+          ...describeError(error),
+        })
+      );
+      Sentry.logger.info("initDb: sync retried after change-log repair", {
+        ok: syncResult.ok,
+      });
+    }
+  }
+
   Sentry.logger.info("initDb: post-migration sync complete", {
     ok: syncResult.ok,
   });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     target: "es2022",
 
     rollupOptions: {
-      external: ["workbox-window"],
       output: {
         // Keep sync-wasm in its own chunk. It self-spawns a worker via
         // `new Worker(import.meta.url, { type: "module" })`; if its code is


### PR DESCRIPTION
Closes BAH-186.

## The problem

Three users' web clients have not pushed to Turso since 2026-07-20. Their local writes — including a full dictionary import — exist only in browser OPFS and have never reached the server. Push fails every cycle with:

```
database tape error: column 3 type mismatch:
expected integer, got 'Text(Text { value: "flashcards", subtype: Text })'
```

It's silent by design: `route.tsx` deliberately swallows sync errors so people can keep working offline, so the app looks fine while sync fails every 15s indefinitely. Nobody noticed for five days.

## Root cause

`turso_cdc` is the sync engine's internal change log, local to each browser. Push reads it to work out what to send. Bumping `@tursodatabase/sync-wasm` 0.3.2 → 0.6.1 inserted a `change_txn_id` column into the middle of it.

**0.6.1 handles that upgrade correctly on its own** — it reads pending old-layout entries, pushes them, then migrates the table. Verified: a seeded un-pushed entry reached the server. A plain old→new upgrade is not the bug.

The break needs an older engine to run *after* the upgrade. Entries are written positionally at the storage layer, so every field lands one column off:

| index | 0.3.2 writes | 0.6.1 expects | landed |
|---|---|---|---|
| 2 | change_type | `change_txn_id` | `1` |
| 3 | **table_name** | **change_type** | `"dictionary_entries"` |
| 4 | id | table_name | `2` |

SQLite has type *affinity*, not enforcement, so text lands in an INTEGER column without complaint. The entry can never be parsed or drained afterwards, so every later push fails on it — permanently, across releases.

## Why an old engine was still running

**Service worker registration has been broken since Aug 2024.** `registerSW()` awaits `import("workbox-window")`; `external: ["workbox-window"]` in `vite.config.ts` left that a bare specifier, which browsers cannot resolve without an import map. The promise rejects, `.catch()` swallows it into an `onRegisterError` handler we don't provide, and registration silently never happens.

Consequences: `onRegisteredSW` never fires, so the hourly update poll added in `3099c3c` has never run once; and the `activated` → `window.location.reload()` handler never attaches, so a client can run a stale bundle indefinitely.

Confirmed against production — the deployed bundle still contains the unresolvable bare specifier, and a fresh profile reports `registrationCount: 0`.

## What this changes

**Drop `external: ["workbox-window"]`.** Restores registration, the update poll, and the reload-on-activate that pulls clients onto new code. This is the fix that stops it recurring.

**Repair poisoned logs on init.** When push fails with a change-log parse error, delete only the malformed entries and retry once. `typeof()` reports a value's real storage class rather than the column's declared type, so it matches exactly the entries written under the wrong layout and leaves well-formed pending changes to push normally. **No user table is touched.**

Deliberately scoped to this known corruption rather than general. Two attempts at generality were worse — an unconditional clear discards well-formed pending entries, which forced regenerating them by deleting and reinserting user rows, and `flashcards.dictionary_entry_id` is `ON DELETE cascade`, so that would have destroyed FSRS scheduling state.

**Request persistent storage.** The code only ever *read* `persisted()` for telemetry; `persist()` was never called. Affected users report `persisted: false`, meaning Chrome can evict their unsynced data with no warning. Adds a `persistGranted` field so we can see whether the request lands.

**Cache headers.** `sw.js` pinned to `no-cache`, hashed assets marked immutable. Pages defaults both to four hours.

## Verification

Ran against real 0.3.2 and 0.6.1 builds sharing one OPFS profile.

A log holding two genuine healthy entries plus one genuine poisoned entry recovers in a single init: the poisoned entry is removed, the healthy ones survive and reach the server (confirmed from a clean profile that could only have pulled them).

Service worker: registration goes 0 → 1 and the page becomes controlled; a client holding a stale bundle detects a new deploy and force-reloads onto it.

Not asserted: idempotency, and a deliberate negative case on a healthy database — though the healthy path ran many times during testing without the repair firing.

## Rollout notes

The first load after this ships registers a worker for everyone who currently has none, which means **one reload flash and a ~12.9 MB precache** (11 MB of it the wasm). Every affected user is on Android Chrome, so that's a real data cost — worth shipping when you're happy for it to land.

Existing legacy-worker clients lag one navigation: their page still runs the old bundle, so the browser's own `sw.js` byte-check is what picks up the new worker, and the load after that gets the fix.

The service-worker change is the riskier half and could be split out if you'd rather land the repair first.

## Known limits

- Writes made during a stale-bundle session are lost with the poisoned entries, and deletions from that session reappear on the next pull. Both bounded to one session; nothing the user still has is destroyed.
- `database tape error` is a broader class than this corruption — a malformed payload reports the same way. The repair no-ops safely when it finds nothing to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYvbgdnHELDm18RL3WvGmW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database synchronization by automatically recovering from certain corrupted local sync states and retrying the operation.
  * Improved reliability when loading service workers after deployments by preventing stale versions from being reused.

* **Performance**
  * Added long-term caching for versioned assets, helping repeat visits load faster and reducing unnecessary downloads.

* **Monitoring**
  * Added additional diagnostics for storage persistence and synchronization recovery outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->