### PR TITLE
fix(mobile): mark form dirty on autofill so Save enables

### DIFF
--- a/apps/mobile/src/components/dictionary/form/AutofillButton.tsx
+++ b/apps/mobile/src/components/dictionary/form/AutofillButton.tsx
@@ -2,7 +2,7 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Sparkles } from "lucide-react-native";
 import { useState } from "react";
-import { useFormContext } from "react-hook-form";
+import { type UseFormSetValue, useFormContext } from "react-hook-form";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import { toast } from "sonner-native";
 import type { z } from "zod";
@@ -17,7 +17,13 @@ export const AutofillButton = () => {
   const colors = useThemeColors();
   const { isProUser } = useUserPlan();
   const [isLoading, setIsLoading] = useState(false);
-  const { setValue, watch } = useFormContext<FormData>();
+  const { setValue: setFieldValue, watch } = useFormContext<FormData>();
+
+  // Mark autofilled fields dirty so the Save button (gated on isDirty) enables.
+  // setValue defaults to shouldDirty: false, which left autofill-only edits
+  // unsaveable.
+  const setValue: UseFormSetValue<FormData> = (name, value, options) =>
+    setFieldValue(name, value, { shouldDirty: true, ...options });
 
   const word = watch("word");
   const translation = watch("translation");


### PR DESCRIPTION
## Problem

On the mobile edit-word screen, using **Autofill** (AI-populate) doesn't enable the **Save** button. Save is gated on react-hook-form's `isDirty`, and `AutofillButton` set every field with `setValue(name, value)` — which defaults to `shouldDirty: false`. So an autofill-only edit left the form "clean" and unsaveable.

## Change

Wrap `setValue` in `AutofillButton` to pass `{ shouldDirty: true }` for every field it writes, so autofilled changes flip `isDirty` and Save enables. The wrapper keeps the existing call sites unchanged.

## Notes

- `AutofillButton` is shared by edit-word and add-word, so both benefit.
- Type-checks clean (mobile). No behavior change beyond the form now registering autofill as an edit.