### PR TITLE
chore(mobile): log flashcard translation layout and both data sources

### DIFF
--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Trans } from "@lingui/react/macro";
+import * as Sentry from "@sentry/react-native";
 import * as Haptics from "expo-haptics";
 import { ChevronDown } from "lucide-react-native";
 import type React from "react";
@@ -11,9 +12,12 @@ import { useCallback, useEffect } from "react";
 import {
   Dimensions,
   I18nManager,
+  type LayoutChangeEvent,
+  type NativeSyntheticEvent,
   ScrollView,
   StyleSheet,
   Text,
+  type TextLayoutEventData,
   View,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -277,6 +281,55 @@ const QuestionContent: React.FC<QuestionContentProps> = ({
   </View>
 );
 
+/**
+ * TEMPORARY DIAGNOSTIC (translation truncation on the answer side).
+ *
+ * onTextLayout reports the lines RN actually laid out, so joining their text
+ * back together and comparing it to the source string says whether the
+ * truncation happens at layout time or before the string ever reaches here.
+ * `laidOutText` shorter than `sourceText` means RN dropped content while laying
+ * it out; equal means the glyphs exist and something clips them afterwards.
+ *
+ * JSON.stringify is deliberate on both strings -- it makes newlines, trailing
+ * whitespace and any zero-width characters visible in Sentry instead of
+ * silently rendering as nothing.
+ */
+const logTranslationTextLayout = ({
+  entry,
+  event,
+}: {
+  entry: FlashcardWithDictionaryEntry["dictionary_entry"];
+  event: NativeSyntheticEvent<TextLayoutEventData>;
+}) => {
+  const { lines } = event.nativeEvent;
+  const laidOutText = lines.map((line) => line.text).join("");
+
+  Sentry.logger.info("flashcard.answer.translationTextLayout", {
+    operation: "flashcard.translationTruncation",
+    entryId: entry.id,
+    word: entry.word,
+    sourceText: JSON.stringify(entry.translation),
+    sourceLength: entry.translation.length,
+    laidOutText: JSON.stringify(laidOutText),
+    laidOutLength: laidOutText.length,
+    droppedCharacters: entry.translation.length - laidOutText.length,
+    lineCount: lines.length,
+    lineWidths: lines.map((line) => Math.round(line.width)),
+    lineHeights: lines.map((line) => Math.round(line.height)),
+  });
+};
+
+/** TEMPORARY DIAGNOSTIC: width the translation actually got to wrap within. */
+const logTranslationBoxLayout = (event: LayoutChangeEvent) => {
+  const { width, height } = event.nativeEvent.layout;
+
+  Sentry.logger.info("flashcard.answer.translationBoxLayout", {
+    operation: "flashcard.translationTruncation",
+    width: Math.round(width),
+    height: Math.round(height),
+  });
+};
+
 interface AnswerContentProps {
   entry: FlashcardWithDictionaryEntry["dictionary_entry"];
   isReverse: boolean;
@@ -306,14 +359,17 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
   >
     {tags.length > 0 && <TagsRow tags={tags} />}
 
-    <View className="items-center gap-1">
+    <View className="items-center gap-1" onLayout={logTranslationBoxLayout}>
       <Text
         className="text-center font-bold text-3xl text-foreground leading-relaxed"
         style={{ writingDirection: "rtl" }}
       >
         {entry.word}
       </Text>
-      <Text className="text-center font-medium text-foreground text-xl">
+      <Text
+        className="text-center font-medium text-foreground text-xl"
+        onTextLayout={(event) => logTranslationTextLayout({ entry, event })}
+      >
         {entry.translation}
       </Text>
     </View>

--- a/apps/mobile/src/components/flashcards/FlashcardReview.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardReview.tsx
@@ -21,6 +21,7 @@ import { type LayoutChangeEvent, Pressable, Text, View } from "react-native";
 import ReAnimated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { type Grade, Rating } from "ts-fsrs";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
+import { getIndexedEntry } from "@/lib/search";
 import { useThemeColors } from "@/lib/theme";
 import {
   DEFAULT_BACKLOG_THRESHOLD_DAYS,
@@ -258,6 +259,41 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
   useEffect(() => {
     setShowAnswer(false);
   }, [currentCard?.id]);
+
+  // TEMPORARY DIAGNOSTIC (translation truncation on the answer side). The card
+  // renders the translation off the Turso row, while every other surface that
+  // shows translations renders the Orama search document -- two separate
+  // pipelines for the same field. Logs both for the card on screen so they can
+  // be compared against what was actually displayed.
+  useEffect(() => {
+    if (!currentCard) return;
+
+    const entry = currentCard.dictionary_entry;
+
+    getIndexedEntry(entry.id)
+      .then((indexed) => {
+        const indexedTranslation = indexed?.translation ?? null;
+
+        Sentry.logger.info("flashcard.answer.translationSources", {
+          operation: "flashcard.translationTruncation",
+          entryId: entry.id,
+          word: entry.word,
+          tursoText: JSON.stringify(entry.translation),
+          tursoLength: entry.translation.length,
+          indexedText: JSON.stringify(indexedTranslation),
+          indexedLength: indexedTranslation?.length ?? null,
+          sourcesMatch: indexedTranslation === entry.translation,
+          indexedDocumentFound: Boolean(indexed),
+        });
+      })
+      .catch((err) => {
+        Sentry.logger.warn("flashcard.answer.translationSources failed", {
+          operation: "flashcard.translationTruncation",
+          entryId: entry.id,
+          error: String(err),
+        });
+      });
+  }, [currentCard]);
 
   const fsrsInput = useMemo(
     () =>

--- a/apps/mobile/src/lib/search/index.ts
+++ b/apps/mobile/src/lib/search/index.ts
@@ -17,6 +17,7 @@ import {
 import { err, ok, type Result } from "@bahar/result";
 import {
   createDictionaryDatabase,
+  getDocument,
   insertDocument,
   insertDocuments,
   removeDocument,
@@ -396,6 +397,14 @@ export const search = async (
 ) => {
   const orama = getOramaDb();
   return searchDictionary(orama, term, options);
+};
+
+/**
+ * Reads an indexed document straight out of the search index by id.
+ */
+export const getIndexedEntry = async (id: string) => {
+  const orama = getOramaDb();
+  return getDocument(orama, id);
 };
 
 export {

--- a/packages/search/src/database.ts
+++ b/packages/search/src/database.ts
@@ -4,6 +4,7 @@
 
 import {
   create,
+  getByID,
   type InternalTypedDocument,
   insert,
   insertMultiple,
@@ -97,6 +98,13 @@ export const updateDocument = (
  */
 export const removeDocument = (db: DictionaryOrama, id: string) => {
   return remove(db, id);
+};
+
+/**
+ * Reads a single indexed document by id, without going through search.
+ */
+export const getDocument = (db: DictionaryOrama, id: string) => {
+  return getByID(db, id);
 };
 
 type SearchableProperties = keyof typeof dictionarySchema;


### PR DESCRIPTION
## Problem

Multi-line translations are intermittently displayed truncated on the flashcard answer side in the mobile app, and only there. The stored string is correct and renders in full on every other surface. Deleting a translation and retyping the identical text makes that entry render correctly from then on.

That last detail rules out the two obvious explanations: the stored data is fine, and static layout can't be intermittent — neither depends on having retyped identical content. The truncation is also silent (no ellipsis, no scroll affordance), so it reads as a correct-but-wrong translation, which has already caused real review mistakes.

## What this adds

Temporary instrumentation to separate "the string arrived short" from "the string is complete and rendered short", rather than continuing to guess. Three Sentry logs, all tagged `operation: "flashcard.translationTruncation"`:

| Log | Answers |
| --- | --- |
| `flashcard.answer.translationTextLayout` | What RN actually laid out. Joins the laid-out lines and diffs against the source, so `droppedCharacters` says whether content is lost during layout. |
| `flashcard.answer.translationBoxLayout` | The width the translation had to wrap within. |
| `flashcard.answer.translationSources` | The translation from both data pipelines for the card on screen, plus `sourcesMatch`. |

The two pipelines matter because the flashcard renders the translation off the **Turso row** (`today.query` returns the joined `dictionary_entry`), whereas the surfaces that display it correctly render the **Orama search document**. Same field, different sources, so they can disagree.

Both strings are logged via `JSON.stringify` so newlines, trailing whitespace and zero-width characters show up in Sentry instead of rendering as nothing — relevant since multi-line content is the trigger.

Also adds `getDocument` to the search package, alongside the existing `insertDocument`/`updateDocument`/`removeDocument`, so an indexed document can be read by id without running a search query.

## How to read the result

On a card that truncates:

- `droppedCharacters: 0` with `lineCount: 1` on a long string means the glyphs all exist and something clips them; the box `width` then says whether the wrap constraint was wrong.
- `droppedCharacters > 0` means RN dropped content during layout.
- A `lineCount` higher than what was visible on screen means it laid out correctly and was clipped afterwards.

Filter Sentry Logs by `trace:<trace_id>` to line all three up for a single card.

## Reviewer notes

- **This is diagnostic only — no behavior change, and it should be reverted once the cause is known.**
- While it is in place it sends dictionary content (translation strings) to Sentry. Deliberate, since comparing the two sources requires the actual strings.
- Verified with `biome check` and mobile `tsc --noEmit` (clean apart from two pre-existing errors in `button.tsx` and `expo-file-system`). Not yet run on a device — that is the next step and the whole point of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)