### PR TITLE
fix(flashcards): reset only the cards a word actually has

### DIFF
--- a/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
+++ b/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
@@ -145,15 +145,9 @@ export default function EditWordScreen() {
     }: {
       dictionary_entry_id: string;
     }) => {
-      // Reverse cards are optional per word, so only reset the ones that exist.
-      const existing =
-        await flashcardsTable.findByEntryId.query(dictionary_entry_id);
-
-      const results = await Promise.all(
-        existing.map(({ direction }) =>
-          flashcardsTable.reset.mutation({ dictionary_entry_id, direction })
-        )
-      );
+      const results = await flashcardsTable.resetEntry.mutation({
+        dictionary_entry_id,
+      });
 
       // Post the manual reset revlogs to the server (fire-and-forget).
       for (const { flashcard, log } of results) {

--- a/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
+++ b/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
@@ -145,16 +145,15 @@ export default function EditWordScreen() {
     }: {
       dictionary_entry_id: string;
     }) => {
-      const results = await Promise.all([
-        flashcardsTable.reset.mutation({
-          dictionary_entry_id,
-          direction: "forward",
-        }),
-        flashcardsTable.reset.mutation({
-          dictionary_entry_id,
-          direction: "reverse",
-        }),
-      ]);
+      // Reverse cards are optional per word, so only reset the ones that exist.
+      const existing =
+        await flashcardsTable.findByEntryId.query(dictionary_entry_id);
+
+      const results = await Promise.all(
+        existing.map(({ direction }) =>
+          flashcardsTable.reset.mutation({ dictionary_entry_id, direction })
+        )
+      );
 
       // Post the manual reset revlogs to the server (fire-and-forget).
       for (const { flashcard, log } of results) {

--- a/apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx
+++ b/apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx
@@ -73,16 +73,15 @@ const ResetFlashcardButton: FC<{ id: string }> = ({ id }) => {
     }: {
       dictionary_entry_id: string;
     }) => {
-      const results = await Promise.all([
-        flashcardsTable.reset.mutation({
-          dictionary_entry_id,
-          direction: "forward",
-        }),
-        flashcardsTable.reset.mutation({
-          dictionary_entry_id,
-          direction: "reverse",
-        }),
-      ]);
+      // Reverse cards are optional per word, so only reset the ones that exist.
+      const existing =
+        await flashcardsTable.findByEntryId.query(dictionary_entry_id);
+
+      const results = await Promise.all(
+        existing.map(({ direction }) =>
+          flashcardsTable.reset.mutation({ dictionary_entry_id, direction })
+        )
+      );
 
       await Promise.all(
         results.map(({ flashcard, log }) =>

--- a/apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx
+++ b/apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx
@@ -73,15 +73,9 @@ const ResetFlashcardButton: FC<{ id: string }> = ({ id }) => {
     }: {
       dictionary_entry_id: string;
     }) => {
-      // Reverse cards are optional per word, so only reset the ones that exist.
-      const existing =
-        await flashcardsTable.findByEntryId.query(dictionary_entry_id);
-
-      const results = await Promise.all(
-        existing.map(({ direction }) =>
-          flashcardsTable.reset.mutation({ dictionary_entry_id, direction })
-        )
-      );
+      const results = await flashcardsTable.resetEntry.mutation({
+        dictionary_entry_id,
+      });
 
       await Promise.all(
         results.map(({ flashcard, log }) =>

--- a/packages/db-operations/src/operations/flashcards.test.ts
+++ b/packages/db-operations/src/operations/flashcards.test.ts
@@ -186,6 +186,138 @@ describe("flashcardsTable", () => {
     });
   });
 
+  describe("resetEntry", () => {
+    it("resets both cards when the word has a forward and a reverse card", async () => {
+      const entry = await insertDictionaryEntry(testDb);
+      await insertFlashcard(testDb, {
+        dictionary_entry_id: entry.id,
+        direction: "forward",
+        state: FlashcardState.REVIEW,
+        stability: 10,
+        reps: 5,
+      });
+      await insertFlashcard(testDb, {
+        dictionary_entry_id: entry.id,
+        direction: "reverse",
+        state: FlashcardState.REVIEW,
+        stability: 8,
+        reps: 3,
+      });
+
+      const results = await flashcardsTable.resetEntry.mutation({
+        dictionary_entry_id: entry.id,
+      });
+
+      expect(results).toHaveLength(2);
+      expect(
+        results.map(({ flashcard }) => flashcard.direction).sort()
+      ).toEqual(["forward", "reverse"]);
+
+      for (const { flashcard } of results) {
+        expect(flashcard).toMatchObject({
+          state: FlashcardState.NEW,
+          stability: 0,
+          difficulty: 0,
+          reps: 0,
+          lapses: 0,
+          elapsed_days: 0,
+          scheduled_days: 0,
+          last_review: null,
+        });
+      }
+    });
+
+    // Regression: a word with no reverse row used to throw
+    // "Flashcard not found ... direction: reverse" after the forward card had
+    // already been written, leaving the reset half-done.
+    it("resets the forward card of a word that has no reverse card", async () => {
+      const entry = await insertDictionaryEntry(testDb);
+      const forward = await insertFlashcard(testDb, {
+        dictionary_entry_id: entry.id,
+        direction: "forward",
+        state: FlashcardState.REVIEW,
+        stability: 10,
+        reps: 5,
+      });
+
+      const results = await flashcardsTable.resetEntry.mutation({
+        dictionary_entry_id: entry.id,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.flashcard).toMatchObject({
+        id: forward.id,
+        direction: "forward",
+        state: FlashcardState.NEW,
+        stability: 0,
+        reps: 0,
+      });
+
+      const stored = await flashcardsTable.findByEntryId.query(entry.id);
+
+      expect(stored).toHaveLength(1);
+      expect(stored[0]).toMatchObject({
+        id: forward.id,
+        state: FlashcardState.NEW,
+        stability: 0,
+        reps: 0,
+        last_review: null,
+      });
+    });
+
+    it("returns a manual review log per reset card capturing its pre-reset state", async () => {
+      const entry = await insertDictionaryEntry(testDb);
+      await insertFlashcard(testDb, {
+        dictionary_entry_id: entry.id,
+        direction: "forward",
+        state: FlashcardState.REVIEW,
+        stability: 10,
+      });
+      await insertFlashcard(testDb, {
+        dictionary_entry_id: entry.id,
+        direction: "reverse",
+        state: FlashcardState.LEARNING,
+        stability: 4,
+      });
+
+      const results = await flashcardsTable.resetEntry.mutation({
+        dictionary_entry_id: entry.id,
+      });
+
+      // Callers post these logs to the revlog API, which is what puts a "reset"
+      // entry in the review history. Each log is rated Manual and carries its
+      // own card's pre-reset values, not the reset-to-NEW ones and not the
+      // other direction's.
+      const forwardLog = results.find(
+        ({ flashcard }) => flashcard.direction === "forward"
+      )?.log;
+      const reverseLog = results.find(
+        ({ flashcard }) => flashcard.direction === "reverse"
+      )?.log;
+
+      expect(forwardLog).toMatchObject({
+        rating: Rating.Manual,
+        state: FlashcardState.REVIEW,
+        stability: 10,
+      });
+      expect(reverseLog).toMatchObject({
+        rating: Rating.Manual,
+        state: FlashcardState.LEARNING,
+        stability: 4,
+      });
+    });
+
+    it("returns an empty list for an entry with no flashcards at all", async () => {
+      const entry = await insertDictionaryEntry(testDb);
+
+      // Nothing to reset is not an error -- callers skip the revlog posts
+      // instead of failing the whole reset.
+      await expect(
+        flashcardsTable.resetEntry.mutation({ dictionary_entry_id: entry.id })
+      ).resolves.toEqual([]);
+    });
+  });
+
   describe("findByEntryId", () => {
     it("returns all flashcards for a dictionary entry", async () => {
       const entry = await insertDictionaryEntry(testDb);

--- a/packages/db-operations/src/operations/flashcards.ts
+++ b/packages/db-operations/src/operations/flashcards.ts
@@ -459,6 +459,52 @@ export const makeFlashcardsTable = (
         queryKey: ["turso.flashcards.reset"],
       },
     },
+    /**
+     * Resets every flashcard a word actually has. Reverse cards are optional
+     * per word (see `createFlashcardPair` / `setReverse`), so callers cannot
+     * assume a forward/reverse pair -- asking for a direction that has no row
+     * throws, which would abandon the reset half-done.
+     */
+    resetEntry: {
+      mutation: ({
+        dictionary_entry_id,
+      }: {
+        dictionary_entry_id: string;
+      }): Promise<{ flashcard: SelectFlashcard; log: ReviewLog }[]> =>
+        enqueueDbOperation(async () => {
+          const drizzleDb = await getDb();
+          const now = new Date();
+          const scheduler = createScheduler();
+
+          const existing = await drizzleDb
+            .select()
+            .from(flashcards)
+            .where(eq(flashcards.dictionary_entry_id, dictionary_entry_id));
+
+          const results: { flashcard: SelectFlashcard; log: ReviewLog }[] = [];
+
+          for (const current of existing) {
+            const { card, log } = forgetFlashcard(scheduler, current, now);
+
+            const [res] = await drizzleDb
+              .update(flashcards)
+              .set(card)
+              .where(eq(flashcards.id, current.id))
+              .returning();
+
+            if (!res) {
+              throw new Error(`Flashcard not found: ${current.id}`);
+            }
+
+            results.push({ flashcard: res, log });
+          }
+
+          return results;
+        }),
+      cacheOptions: {
+        queryKey: ["turso.flashcards.resetEntry"],
+      },
+    },
     findByEntryId: {
       query: async (entryId: string): Promise<SelectFlashcard[]> => {
         const drizzleDb = await getDb();


### PR DESCRIPTION
## Problem

Resetting a flashcard from the edit-word screen fails for any word that has no reverse card.

The reset button hardcoded a reset of both directions:

```ts
await Promise.all([
  flashcardsTable.reset.mutation({ dictionary_entry_id, direction: "forward" }),
  flashcardsTable.reset.mutation({ dictionary_entry_id, direction: "reverse" }),
]);
```

But reverse cards are optional per word — a word only has one if `create_reverse_by_default` was on when it was created, or if the per-word reverse toggle added one later. For a word without one, the reverse reset throws `Flashcard not found for dictionary entry: <id>, direction: reverse`.

The forward reset has already committed its write by then, so the user sees the card reset — but the rejected `Promise.all` skips everything after it:

- the revlog `POST` never runs, so no `source: "reset"` entry shows up in the review history
- `onSuccess` never runs, so caches aren't invalidated and the user gets a "Failed to reset flashcard" toast on a reset that partly succeeded

Reported on mobile via Sentry (BAHAR-MOBILE-1, 3 events). Web has the same code path and the same bug; no prod events for it yet.

## Change

Add a `resetEntry` mutation to `packages/db-operations/src/operations/flashcards.ts` that resets whatever cards the entry actually has, and call it from both edit-word screens.

The pair semantics now live next to `createFlashcardPair` / `setReverse`, which are what create (and delete) those rows in the first place, instead of each screen re-deriving the set of directions. It also makes the reset one queued db operation instead of one per card. The single-direction `reset` mutation is unchanged — throwing on a genuinely missing card is still correct there.

Touched:

- `packages/db-operations/src/operations/flashcards.ts`
- `apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx`
- `apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx`

## Testing

New `resetEntry` tests in `packages/db-operations/src/operations/flashcards.test.ts`, running against the real-database harness: both directions present, forward-only (the regression case), the per-card manual review logs callers post to build the review history, and an entry with no cards.

Verified the regression tests bite — reintroducing the both-directions assumption inside `resetEntry` fails them; with the fix, all 126 tests in the package pass. `tsc --noEmit` clean on web and `db-operations`; mobile reports only a pre-existing error in `src/components/ui/button.tsx`, unrelated to this change.

The screens themselves are still untested (neither app has route/screen test infrastructure), so the revlog POST and toast wiring is worth one manual pass: reset a word with no reverse card, confirm the success toast and a "reset" entry in its review history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flashcard resets for dictionary entries so both forward and reverse cards are reset together.
  * Ensured entries without a reverse card still reset correctly.
  * Entries with no flashcards now complete without errors.
  * Review history and statistics are updated consistently after resets.
* **Reliability**
  * Reset results now preserve each card’s previous progress details independently, preventing information from one card direction from overwriting another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->