### PR TITLE
fix(mobile): stop silently cutting off multi-line flashcard translations

### DIFF
--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -52,14 +52,6 @@ interface FlashcardCardProps {
   onFlip: () => void;
   onSwipeLeft?: () => void;
   onSwipeRight?: () => void;
-  /**
-   * Height of the area the card is centered in, measured by the parent. Caps
-   * the answer scroll view: the card is content-sized (its container centers
-   * rather than stretches it), so without a ceiling the scroll view grows to
-   * fit its content, spills out of an unclipped parent, and gets painted over
-   * by the grade buttons below it.
-   */
-  availableHeight?: number;
 }
 
 const TagsRow: React.FC<{ tags: string[] }> = ({ tags }) => {
@@ -81,7 +73,6 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
   onFlip,
   onSwipeLeft,
   onSwipeRight,
-  availableHeight,
 }) => {
   const translateX = useSharedValue(0);
   const rotation = useSharedValue(0);
@@ -199,8 +190,13 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
 
   return (
     <GestureDetector gesture={composedGesture}>
+      {/* shrink lets the flex chain bound the card's height. RN defaults
+          flexShrink to 0 (web defaults to 1), so without it the card refuses to
+          shrink below its content height and overflows the card area instead --
+          which is what previously forced the scroll view to be capped with a
+          measured pixel value. */}
       <Animated.View
-        className="overflow-hidden rounded-3xl border border-border/50 bg-card shadow-xl"
+        className="shrink overflow-hidden rounded-3xl border border-border/50 bg-card shadow-xl"
         style={[cardStyle]}
       >
         <Animated.View
@@ -214,11 +210,17 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
           style={[goodOverlayStyle, StyleSheet.absoluteFill]}
         />
 
-        {showAnswer ? (
-          <ScrollView
-            showsVerticalScrollIndicator
-            style={[styles.scroll, { maxHeight: availableHeight }]}
-          >
+        {/* One scroll container for both sides rather than a scrollable answer
+            and an unbounded question. Its height comes from the shrinking flex
+            chain above, so whichever side overflows becomes scrollable on its
+            own -- no measured ceiling to keep in sync with the device, the
+            orientation or the OS font scale. */}
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator
+          style={styles.scroll}
+        >
+          {showAnswer ? (
             <AnswerContent
               entry={entry}
               examples={examples}
@@ -227,10 +229,10 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
               tags={tags}
               verb={verb}
             />
-          </ScrollView>
-        ) : (
-          <QuestionContent entry={entry} isReverse={isReverse} tags={tags} />
-        )}
+          ) : (
+            <QuestionContent entry={entry} isReverse={isReverse} tags={tags} />
+          )}
+        </ScrollView>
       </Animated.View>
     </GestureDetector>
   );
@@ -367,7 +369,10 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
         already committed one line short -- the overflow is clipped by the card's
         overflow-hidden, silently dropping part of the translation. A definite
         width means the measure and layout passes agree. */}
-    <View className="w-full items-center gap-1" onLayout={logTranslationBoxLayout}>
+    <View
+      className="w-full items-center gap-1"
+      onLayout={logTranslationBoxLayout}
+    >
       <Text
         className="text-center font-bold text-3xl text-foreground leading-relaxed"
         style={{ writingDirection: "rtl" }}
@@ -455,5 +460,12 @@ const hasMorphology = (ism: Ism, verb: Verb) =>
 const styles = StyleSheet.create({
   scroll: {
     width: "100%",
+    flexShrink: 1,
+  },
+  // Lets the question side keep filling the card (its min height plus
+  // justify-between spacing) while still allowing the content to grow taller
+  // than the scroll view and scroll.
+  scrollContent: {
+    flexGrow: 1,
   },
 });

--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -359,7 +359,15 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
   >
     {tags.length > 0 && <TagsRow tags={tags} />}
 
-    <View className="items-center gap-1" onLayout={logTranslationBoxLayout}>
+    {/* w-full is load-bearing, not cosmetic. The parent centers its children
+        (items-center), so without an explicit width this box is content-sized:
+        its height gets measured from the text at its *unconstrained* width,
+        which never wraps and so reports a single line. The box then lays out at
+        the card's narrower width, the text wraps to two lines, and the height is
+        already committed one line short -- the overflow is clipped by the card's
+        overflow-hidden, silently dropping part of the translation. A definite
+        width means the measure and layout passes agree. */}
+    <View className="w-full items-center gap-1" onLayout={logTranslationBoxLayout}>
       <Text
         className="text-center font-bold text-3xl text-foreground leading-relaxed"
         style={{ writingDirection: "rtl" }}
@@ -377,7 +385,7 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
     <PropertiesRow morphology={entry.morphology} type={entry.type} />
 
     {entry.definition && (
-      <Text className="text-center text-[13px] text-muted-foreground">
+      <Text className="w-full text-center text-[13px] text-muted-foreground">
         {entry.definition}
       </Text>
     )}

--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Trans } from "@lingui/react/macro";
-import * as Sentry from "@sentry/react-native";
 import * as Haptics from "expo-haptics";
 import { ChevronDown } from "lucide-react-native";
 import type React from "react";
@@ -12,12 +11,9 @@ import { useCallback, useEffect } from "react";
 import {
   Dimensions,
   I18nManager,
-  type LayoutChangeEvent,
-  type NativeSyntheticEvent,
   ScrollView,
   StyleSheet,
   Text,
-  type TextLayoutEventData,
   View,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -283,55 +279,6 @@ const QuestionContent: React.FC<QuestionContentProps> = ({
   </View>
 );
 
-/**
- * TEMPORARY DIAGNOSTIC (translation truncation on the answer side).
- *
- * onTextLayout reports the lines RN actually laid out, so joining their text
- * back together and comparing it to the source string says whether the
- * truncation happens at layout time or before the string ever reaches here.
- * `laidOutText` shorter than `sourceText` means RN dropped content while laying
- * it out; equal means the glyphs exist and something clips them afterwards.
- *
- * JSON.stringify is deliberate on both strings -- it makes newlines, trailing
- * whitespace and any zero-width characters visible in Sentry instead of
- * silently rendering as nothing.
- */
-const logTranslationTextLayout = ({
-  entry,
-  event,
-}: {
-  entry: FlashcardWithDictionaryEntry["dictionary_entry"];
-  event: NativeSyntheticEvent<TextLayoutEventData>;
-}) => {
-  const { lines } = event.nativeEvent;
-  const laidOutText = lines.map((line) => line.text).join("");
-
-  Sentry.logger.info("flashcard.answer.translationTextLayout", {
-    operation: "flashcard.translationTruncation",
-    entryId: entry.id,
-    word: entry.word,
-    sourceText: JSON.stringify(entry.translation),
-    sourceLength: entry.translation.length,
-    laidOutText: JSON.stringify(laidOutText),
-    laidOutLength: laidOutText.length,
-    droppedCharacters: entry.translation.length - laidOutText.length,
-    lineCount: lines.length,
-    lineWidths: lines.map((line) => Math.round(line.width)),
-    lineHeights: lines.map((line) => Math.round(line.height)),
-  });
-};
-
-/** TEMPORARY DIAGNOSTIC: width the translation actually got to wrap within. */
-const logTranslationBoxLayout = (event: LayoutChangeEvent) => {
-  const { width, height } = event.nativeEvent.layout;
-
-  Sentry.logger.info("flashcard.answer.translationBoxLayout", {
-    operation: "flashcard.translationTruncation",
-    width: Math.round(width),
-    height: Math.round(height),
-  });
-};
-
 interface AnswerContentProps {
   entry: FlashcardWithDictionaryEntry["dictionary_entry"];
   isReverse: boolean;
@@ -369,20 +316,14 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
         already committed one line short -- the overflow is clipped by the card's
         overflow-hidden, silently dropping part of the translation. A definite
         width means the measure and layout passes agree. */}
-    <View
-      className="w-full items-center gap-1"
-      onLayout={logTranslationBoxLayout}
-    >
+    <View className="w-full items-center gap-1">
       <Text
         className="text-center font-bold text-3xl text-foreground leading-relaxed"
         style={{ writingDirection: "rtl" }}
       >
         {entry.word}
       </Text>
-      <Text
-        className="text-center font-medium text-foreground text-xl"
-        onTextLayout={(event) => logTranslationTextLayout({ entry, event })}
-      >
+      <Text className="text-center font-medium text-foreground text-xl">
         {entry.translation}
       </Text>
     </View>

--- a/apps/mobile/src/components/flashcards/FlashcardReview.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardReview.tsx
@@ -21,7 +21,6 @@ import { Pressable, Text, View } from "react-native";
 import ReAnimated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { type Grade, Rating } from "ts-fsrs";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
-import { getIndexedEntry } from "@/lib/search";
 import { useThemeColors } from "@/lib/theme";
 import {
   DEFAULT_BACKLOG_THRESHOLD_DAYS,
@@ -249,41 +248,6 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
   useEffect(() => {
     setShowAnswer(false);
   }, [currentCard?.id]);
-
-  // TEMPORARY DIAGNOSTIC (translation truncation on the answer side). The card
-  // renders the translation off the Turso row, while every other surface that
-  // shows translations renders the Orama search document -- two separate
-  // pipelines for the same field. Logs both for the card on screen so they can
-  // be compared against what was actually displayed.
-  useEffect(() => {
-    if (!currentCard) return;
-
-    const entry = currentCard.dictionary_entry;
-
-    getIndexedEntry(entry.id)
-      .then((indexed) => {
-        const indexedTranslation = indexed?.translation ?? null;
-
-        Sentry.logger.info("flashcard.answer.translationSources", {
-          operation: "flashcard.translationTruncation",
-          entryId: entry.id,
-          word: entry.word,
-          tursoText: JSON.stringify(entry.translation),
-          tursoLength: entry.translation.length,
-          indexedText: JSON.stringify(indexedTranslation),
-          indexedLength: indexedTranslation?.length ?? null,
-          sourcesMatch: indexedTranslation === entry.translation,
-          indexedDocumentFound: Boolean(indexed),
-        });
-      })
-      .catch((err) => {
-        Sentry.logger.warn("flashcard.answer.translationSources failed", {
-          operation: "flashcard.translationTruncation",
-          entryId: entry.id,
-          error: String(err),
-        });
-      });
-  }, [currentCard]);
 
   const fsrsInput = useMemo(
     () =>

--- a/apps/mobile/src/components/flashcards/FlashcardReview.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardReview.tsx
@@ -17,7 +17,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { Archive, Brain, PartyPopper, X } from "lucide-react-native";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { type LayoutChangeEvent, Pressable, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import ReAnimated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { type Grade, Rating } from "ts-fsrs";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
@@ -37,9 +37,6 @@ import { api, queryClient } from "../../utils/api";
 import { FlashcardCard } from "./FlashcardCard";
 import { GradeButtons, ShowAnswerButton } from "./GradeButtons";
 import { GradeFeedback } from "./GradeFeedback";
-
-/** Vertical padding on each side of the card area. Mirrors its `p-4`. */
-const CARD_AREA_PADDING = 16;
 
 interface FlashcardReviewProps {
   filters?: SelectDeck["filters"];
@@ -171,13 +168,6 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
   const [pendingGrade, setPendingGrade] = useState<Grade | null>(null);
   const [cards, setCards] = useState<FlashcardWithDictionaryEntry[]>([]);
   const [initialHasMore, setInitialHasMore] = useState(false);
-  // Measured rather than assumed: the card area is whatever is left after the
-  // header, queue tabs and grade buttons, which varies by device and OS font
-  // scale. The answer scroll view needs this as its ceiling -- see the
-  // availableHeight prop on FlashcardCard.
-  const [cardAreaHeight, setCardAreaHeight] = useState<number | undefined>(
-    undefined
-  );
   const [selectedQueue, setSelectedQueue] =
     useState<FlashcardQueue>(initialQueue);
   const scheduler = useMemo(() => createScheduler(), []);
@@ -335,12 +325,6 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
 
   const handleFlip = useCallback(() => {
     setShowAnswer(true);
-  }, []);
-
-  const handleCardAreaLayout = useCallback((event: LayoutChangeEvent) => {
-    // layout.height is the border box, so drop the padding to get the space
-    // the card actually has to sit in.
-    setCardAreaHeight(event.nativeEvent.layout.height - CARD_AREA_PADDING * 2);
   }, []);
 
   const handleGrade = useCallback(
@@ -553,18 +537,17 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
         selectedQueue={selectedQueue}
       />
 
-      {/* Card area */}
-      <View
-        className="flex-1 justify-center p-4"
-        onLayout={handleCardAreaLayout}
-      >
+      {/* Card area. The card is bounded by this flex chain rather than by a
+          measured pixel height, so `shrink` has to be carried down to it -- RN
+          defaults flexShrink to 0, which would let the card overflow instead. */}
+      <View className="flex-1 justify-center p-4">
         <ReAnimated.View
+          className="shrink"
           entering={FadeIn.duration(200)}
           exiting={FadeOut.duration(150)}
           key={`${selectedQueue}-${currentCard.id}`}
         >
           <FlashcardCard
-            availableHeight={cardAreaHeight}
             flashcard={currentCard}
             onFlip={handleFlip}
             onSwipeLeft={handleSwipeLeft}

--- a/apps/mobile/src/lib/search/index.ts
+++ b/apps/mobile/src/lib/search/index.ts
@@ -17,7 +17,6 @@ import {
 import { err, ok, type Result } from "@bahar/result";
 import {
   createDictionaryDatabase,
-  getDocument,
   insertDocument,
   insertDocuments,
   removeDocument,
@@ -397,14 +396,6 @@ export const search = async (
 ) => {
   const orama = getOramaDb();
   return searchDictionary(orama, term, options);
-};
-
-/**
- * Reads an indexed document straight out of the search index by id.
- */
-export const getIndexedEntry = async (id: string) => {
-  const orama = getOramaDb();
-  return getDocument(orama, id);
 };
 
 export {

--- a/packages/search/src/database.ts
+++ b/packages/search/src/database.ts
@@ -4,7 +4,6 @@
 
 import {
   create,
-  getByID,
   type InternalTypedDocument,
   insert,
   insertMultiple,
@@ -98,13 +97,6 @@ export const updateDocument = (
  */
 export const removeDocument = (db: DictionaryOrama, id: string) => {
   return remove(db, id);
-};
-
-/**
- * Reads a single indexed document by id, without going through search.
- */
-export const getDocument = (db: DictionaryOrama, id: string) => {
-  return getByID(db, id);
 };
 
 type SearchableProperties = keyof typeof dictionarySchema;


### PR DESCRIPTION
## Problem

On the flashcard answer side, multi-line translations were displayed cut off — silently, with no ellipsis and no scroll affordance, so a partial translation read as a complete and correct one. The word خار (`"to grow weak"`) displayed as `"to grow"`. This has caused real review mistakes.

The data was never wrong. Instrumentation on that exact card showed:

| Field | Value |
| --- | --- |
| `sourceText` / `laidOutText` | `"to grow weak"` / `"to grow weak"` |
| `droppedCharacters` | 0 |
| `lineCount` | 2, `lineHeights` `[28, 28]` |
| container `height` | **81** |
| `sourcesMatch` (Turso vs search index) | true |

81pt is exactly the 49pt word + 4pt gap + **one** 28pt line. RN laid out both lines; the box only had room for one.

## Cause

The word/translation box sits under a parent that centers its children (`items-center`), so with no explicit width it is content-sized. Yoga therefore measures its height by asking the text for its intrinsic size at an *unconstrained* width — where text never wraps, so it reports one line. The box is then laid out at the card's narrower real width, the text wraps to two lines, and the height is already committed one line short. `overflow-hidden` on the card clips the remainder.

Length isn't the trigger, **wrapping** is: واهن with the longer `"frail, weak, feeble"` (19 chars vs 12) laid out on one line and rendered fine, because there the measure and layout passes agreed. That's why this looked random, and why retyping the same text fixed one entry — a new string is a new text-measurement cache key.

## Changes

Three commits, independently reviewable and revertable:

1. **`fix: give the flashcard answer text a definite width`** — the actual fix. Also applies to the `definition` text, a wrapping sibling under the same centering parent with the identical latent defect.
2. **`fix: bound the flashcard by its flex chain, not a measured height`** — removes the `onLayout` + `availableHeight` measurement that capped the answer scroll view. That ceiling only existed because the wrappers between the bounded card area and the scroll view couldn't shrink (RN defaults `flexShrink` to `0`, web to `1`). Sets `shrink` and lets the flex chain do the bounding. Also collapses the two branches into a single scroll container — previously only the answer side scrolled while the question side had no ceiling at all, the same bug on the side nobody had hit yet.
3. **`revert: drop the diagnostic logging`** — reverts the instrumentation from #70, and stops sending dictionary content to Sentry.

Net: **-154 / +45**.

`overflow-hidden` is deliberately kept — it clips children to `rounded-3xl` (on Android `borderRadius` doesn't clip without it) and keeps the absolutely-positioned swipe overlays inside the card's corners. It's what made the wrong height *silent* rather than *ugly*; it isn't the cause.

## Reviewer notes

- **Commit 2 cannot fix the truncation on its own** and isn't claimed to. A scroll view can't reveal content the layout never allocated space for — its `contentSize` derives from the same under-reported child heights. It's an architecture fix (this code has already gone hardcoded `580` → measured `~470` → question side never capped); the truncation fix is commit 1.
- **Not yet verified on a device.** `biome` and mobile `tsc --noEmit` are clean (one pre-existing `button.tsx` error). RN layout can't be exercised under jest-expo, so this needs a real run.
- Suggested verification: build at `HEAD~1` (instrumentation still present) and confirm خار logs `lineCount: 2` with `height ≈ 109` rather than 81. Building at `HEAD` removes the logs.
- Worth a look on the question side too, since commit 2 routes it through a ScrollView for the first time — tap-to-flip now passes through it. The answer side already composed pan+tap around a ScrollView in the same `GestureDetector`, so there is precedent, but it deserves a tap test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)