### PR TITLE
fix(mobile): give the flashcard a definite width, and re-instrument to verify

### DIFF
--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -4,16 +4,21 @@
  */
 
 import { Trans } from "@lingui/react/macro";
+import * as Sentry from "@sentry/react-native";
 import * as Haptics from "expo-haptics";
+import * as Updates from "expo-updates";
 import { ChevronDown } from "lucide-react-native";
 import type React from "react";
 import { useCallback, useEffect } from "react";
 import {
   Dimensions,
   I18nManager,
+  type LayoutChangeEvent,
+  type NativeSyntheticEvent,
   ScrollView,
   StyleSheet,
   Text,
+  type TextLayoutEventData,
   View,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -200,6 +205,7 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
           keeps its full content height and overflows the card area. */}
       <Animated.View
         className="w-full shrink overflow-hidden rounded-3xl border border-border/50 bg-card shadow-xl"
+        onLayout={(event) => logCardLayout({ event, node: "card" })}
         style={[cardStyle]}
       >
         <Animated.View
@@ -286,6 +292,76 @@ const QuestionContent: React.FC<QuestionContentProps> = ({
   </View>
 );
 
+/**
+ * TEMPORARY DIAGNOSTIC (translation truncation on the answer side).
+ *
+ * onTextLayout reports the lines RN actually laid out, so joining their text
+ * back together and comparing it to the source string says whether the
+ * truncation happens at layout time or before the string ever reaches here.
+ * `laidOutText` shorter than `sourceText` means RN dropped content while laying
+ * it out; equal means the glyphs exist and something clips them afterwards.
+ *
+ * JSON.stringify is deliberate on both strings -- it makes newlines, trailing
+ * whitespace and any zero-width characters visible in Sentry instead of
+ * silently rendering as nothing.
+ */
+const logTranslationTextLayout = ({
+  entry,
+  event,
+}: {
+  entry: FlashcardWithDictionaryEntry["dictionary_entry"];
+  event: NativeSyntheticEvent<TextLayoutEventData>;
+}) => {
+  const { lines } = event.nativeEvent;
+  const laidOutText = lines.map((line) => line.text).join("");
+
+  Sentry.logger.info("flashcard.answer.translationTextLayout", {
+    operation: "flashcard.translationTruncation",
+    entryId: entry.id,
+    word: entry.word,
+    sourceText: JSON.stringify(entry.translation),
+    sourceLength: entry.translation.length,
+    laidOutText: JSON.stringify(laidOutText),
+    laidOutLength: laidOutText.length,
+    droppedCharacters: entry.translation.length - laidOutText.length,
+    lineCount: lines.length,
+    lineWidths: lines.map((line) => Math.round(line.width)),
+    lineHeights: lines.map((line) => Math.round(line.height)),
+  });
+};
+
+/**
+ * TEMPORARY DIAGNOSTIC: the resolved width at each level of the chain.
+ *
+ * A single width was not enough to reason about: one card's translation fit
+ * 233pt on one line while another wrapped at around 124pt, and there was no way
+ * to tell which node was responsible. Logging card, content and box separately
+ * shows where the width actually comes from, and whether they now agree.
+ *
+ * `buildId` matters because this ships over OTA, where an update applies on the
+ * second cold launch by default -- without it a stale bundle is indistinguishable
+ * from a fix that did not work.
+ */
+const logCardLayout = ({
+  event,
+  node,
+}: {
+  event: LayoutChangeEvent;
+  node: "card" | "answerContent" | "translationBox";
+}) => {
+  const { width, height } = event.nativeEvent.layout;
+
+  Sentry.logger.info("flashcard.answer.layout", {
+    operation: "flashcard.translationTruncation",
+    node,
+    width: Math.round(width),
+    height: Math.round(height),
+    buildId: Updates.updateId ?? "embedded",
+    runtimeVersion: Updates.runtimeVersion ?? "unknown",
+    isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+  });
+};
+
 interface AnswerContentProps {
   entry: FlashcardWithDictionaryEntry["dictionary_entry"];
   isReverse: boolean;
@@ -312,6 +388,7 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
   <Animated.View
     className="w-full items-center gap-3.5 px-5 py-5"
     entering={FadeIn.duration(200)}
+    onLayout={(event) => logCardLayout({ event, node: "answerContent" })}
   >
     {tags.length > 0 && <TagsRow tags={tags} />}
 
@@ -323,14 +400,20 @@ const AnswerContent: React.FC<AnswerContentProps> = ({
         already committed one line short -- the overflow is clipped by the card's
         overflow-hidden, silently dropping part of the translation. A definite
         width means the measure and layout passes agree. */}
-    <View className="w-full items-center gap-1">
+    <View
+      className="w-full items-center gap-1"
+      onLayout={(event) => logCardLayout({ event, node: "translationBox" })}
+    >
       <Text
         className="text-center font-bold text-3xl text-foreground leading-relaxed"
         style={{ writingDirection: "rtl" }}
       >
         {entry.word}
       </Text>
-      <Text className="text-center font-medium text-foreground text-xl">
+      <Text
+        className="text-center font-medium text-foreground text-xl"
+        onTextLayout={(event) => logTranslationTextLayout({ entry, event })}
+      >
         {entry.translation}
       </Text>
     </View>

--- a/apps/mobile/src/components/flashcards/FlashcardCard.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardCard.tsx
@@ -186,13 +186,20 @@ export const FlashcardCard: React.FC<FlashcardCardProps> = ({
 
   return (
     <GestureDetector gesture={composedGesture}>
-      {/* shrink lets the flex chain bound the card's height. RN defaults
-          flexShrink to 0 (web defaults to 1), so without it the card refuses to
-          shrink below its content height and overflows the card area instead --
-          which is what previously forced the scroll view to be capped with a
-          measured pixel value. */}
+      {/* w-full makes the card's width definite, taken from the card area
+          (which gets its width from the screen). Without it the card is sized by
+          whatever its widest content happens to be, so every percentage width
+          inside it resolves against an indefinite parent -- which in Yoga means
+          it does not resolve at all. Wrapping text then gets measured at an
+          unconstrained width, reports one line, and has its height committed too
+          short. It also made card width vary wildly between cards: one word's
+          translation fit 233pt on a single line while another wrapped at ~124pt.
+
+          shrink bounds the card's height instead of a measured pixel value. RN
+          defaults flexShrink to 0 (web defaults to 1), so without it the card
+          keeps its full content height and overflows the card area. */}
       <Animated.View
-        className="shrink overflow-hidden rounded-3xl border border-border/50 bg-card shadow-xl"
+        className="w-full shrink overflow-hidden rounded-3xl border border-border/50 bg-card shadow-xl"
         style={[cardStyle]}
       >
         <Animated.View

--- a/apps/mobile/src/components/flashcards/FlashcardReview.tsx
+++ b/apps/mobile/src/components/flashcards/FlashcardReview.tsx
@@ -22,7 +22,7 @@ import ReAnimated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { type Grade, Rating } from "ts-fsrs";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
 import { useSearch } from "@/hooks/useSearch";
-import { markEntryReviewedInIndex } from "@/lib/search";
+import { getIndexedEntry, markEntryReviewedInIndex } from "@/lib/search";
 import { useThemeColors } from "@/lib/theme";
 import {
   DEFAULT_BACKLOG_THRESHOLD_DAYS,
@@ -251,6 +251,41 @@ export const FlashcardReview: React.FC<FlashcardReviewProps> = ({
   useEffect(() => {
     setShowAnswer(false);
   }, [currentCard?.id]);
+
+  // TEMPORARY DIAGNOSTIC (translation truncation on the answer side). The card
+  // renders the translation off the Turso row, while every other surface that
+  // shows translations renders the Orama search document -- two separate
+  // pipelines for the same field. Logs both for the card on screen so they can
+  // be compared against what was actually displayed.
+  useEffect(() => {
+    if (!currentCard) return;
+
+    const entry = currentCard.dictionary_entry;
+
+    getIndexedEntry(entry.id)
+      .then((indexed) => {
+        const indexedTranslation = indexed?.translation ?? null;
+
+        Sentry.logger.info("flashcard.answer.translationSources", {
+          operation: "flashcard.translationTruncation",
+          entryId: entry.id,
+          word: entry.word,
+          tursoText: JSON.stringify(entry.translation),
+          tursoLength: entry.translation.length,
+          indexedText: JSON.stringify(indexedTranslation),
+          indexedLength: indexedTranslation?.length ?? null,
+          sourcesMatch: indexedTranslation === entry.translation,
+          indexedDocumentFound: Boolean(indexed),
+        });
+      })
+      .catch((err) => {
+        Sentry.logger.warn("flashcard.answer.translationSources failed", {
+          operation: "flashcard.translationTruncation",
+          entryId: entry.id,
+          error: String(err),
+        });
+      });
+  }, [currentCard]);
 
   const fsrsInput = useMemo(
     () =>

--- a/apps/mobile/src/lib/search/index.ts
+++ b/apps/mobile/src/lib/search/index.ts
@@ -436,6 +436,14 @@ export const search = async (
   return searchDictionary(orama, term, options);
 };
 
+/**
+ * Reads an indexed document straight out of the search index by id.
+ */
+export const getIndexedEntry = async (id: string) => {
+  const orama = getOramaDb();
+  return getDocument(orama, id);
+};
+
 export {
   findHighlightPositions,
   highlightWithDiacritics,


### PR DESCRIPTION
## Problem

Multi-line translations on the flashcard answer side are still displayed cut off, silently, after #73. It was reported fixed and then reported broken again on the same word (خار, `"to grow weak"` showing as `"to grow"`).

## Why #73 was not enough

#73 added `w-full` to the box holding the word and translation. But `w-full` is a **percentage**, and in Yoga a percentage resolved against a parent whose own width is indefinite does not resolve at all. The card was sized by whatever its widest content happened to be, so the entire chain above that box had an indefinite width — making the fix a no-op in exactly the case that was broken.

The pre-fix telemetry shows the content-sizing directly:

| Word | Translation | Lines | Widths |
| --- | --- | --- | --- |
| أفرط | "to be excessive, go too far" (27 ch) | 1 | `[233]` |
| واهن | "frail, weak, feeble" (19 ch) | 1 | `[155]` |
| خار | "to grow weak" (12 ch) | **2** | `[72, 47]` |

أفرط fits 233pt on one line while خار wraps at roughly 124. If the available width were the same for both, that is impossible — so the card's width varies per card by about a factor of two.

## Changes

1. **`fix: give the flashcard a definite width`** — sets the width on the card itself, which resolves against the card area and ultimately the screen. Every percentage width inside the card then has a definite parent to resolve against. Also makes card width consistent instead of tracking content.

2. **`chore: restore the flashcard layout diagnostic, with build id`** — reverts the revert from #73, plus two additions:
   - Widths at **three levels** (card / answerContent / translationBox) under one `flashcard.answer.layout` message, so we can see which node sets the constraint rather than inferring it from a single number.
   - **`buildId`, `runtimeVersion`, `isEmbeddedLaunch`.** This ships over OTA where, by default, an update applies only on the *second* cold launch — so without build identity a stale bundle is indistinguishable from a fix that did not work. That ambiguity is plausibly part of the fixed-then-broken-again report.

## How to verify

On a card whose translation wraps:

- **translationBox height ≈ 109pt** → fixed. **81pt** → still broken (81 = 49pt word + 4pt gap + a single 28pt line, i.e. one line short).
- **card width consistent across cards** → the content-sizing is gone.
- Check `buildId` on the log lines to confirm you are actually running this bundle.

Filter Sentry Logs by `operation: "flashcard.translationTruncation"`, or by `trace:<trace_id>` to group one card's logs together.

## Reviewer notes

- **The instrumentation is deliberately NOT reverted here.** #73 bundled the fix and the revert together, which is why the fix shipped unverified. This one stays on `main` until confirmed on-device, then gets reverted in a separate follow-up.
- While it is in place it sends dictionary content (translation strings) to Sentry.
- **This fix is a hypothesis, not a confirmed fix.** Two prior explanations for this bug were wrong (a data cause, then a height-only cause). The Yoga percentage-resolution reasoning is sound and the measured widths corroborate the content-sizing, but nothing here has been observed working on a device.
- `biome` clean; mobile `tsc --noEmit` clean apart from a pre-existing `button.tsx` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagnostics for flashcard layouts and translated text to help identify display or truncation issues.
  * Added additional validation to compare displayed flashcard translations with indexed content.
  * Improved monitoring of flashcard rendering and content lookup failures for more reliable troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->