### PR TITLE
fix(mobile): OTA update banner bleeds into the bottom safe area

### DIFF
--- a/apps/mobile/src/components/updates/UpdateBanner.tsx
+++ b/apps/mobile/src/components/updates/UpdateBanner.tsx
@@ -9,6 +9,7 @@ import Animated, {
   withRepeat,
   withTiming,
 } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
 import { useThemeColors } from "@/lib/theme";
 
@@ -24,9 +25,16 @@ export const UpdateBanner: FC<UpdateBannerProps> = ({
   onUpdate,
 }) => {
   const { primary } = useThemeColors();
+  const insets = useSafeAreaInsets();
 
   return (
-    <View className="absolute inset-x-4 bottom-10 z-50" role="alert">
+    <View
+      className="absolute inset-x-4 z-50"
+      role="alert"
+      // Offset by the real bottom inset so the banner floats above the home
+      // indicator instead of bleeding into the safe area on devices with one.
+      style={{ bottom: insets.bottom + 16 }}
+    >
       <View className="flex-row items-center gap-3 rounded-xl border border-border bg-card p-3.5 shadow-lg">
         <View className="size-10 items-center justify-center rounded-lg border border-primary/20 bg-primary/10">
           {status === "available" ? (


### PR DESCRIPTION
## Symptom
The in-app update banner overlaps the bottom safe area (home-indicator) on devices that have one.

## Cause
`UpdateBanner` was pinned with a fixed `bottom-10` (40px) offset, which ignores the device's actual bottom safe-area inset. On devices with a taller inset the 40px isn't enough clearance, so it bleeds in.

## Fix
Offset by `useSafeAreaInsets().bottom + 16` via `style` instead of the fixed class, so the banner floats a consistent gap above the home indicator on every device (and sits 16px from the edge on devices without an inset).

## Test plan
- [ ] Trigger the update banner (available + downloading states) on a device with a home indicator: banner sits above it, no overlap
- [ ] Device without a bottom inset: banner still has a sensible gap from the edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)