### PR TITLE
fix(web): home search stuck empty after reviewing a card

### DIFF
--- a/apps/web/src/hooks/search/useSearch.ts
+++ b/apps/web/src/hooks/search/useSearch.ts
@@ -7,7 +7,7 @@ import {
 import type { DictionaryDocument } from "@bahar/search/schema";
 import type { InternalTypedDocument, Result, Results } from "@orama/orama";
 import { atom, useAtom, useSetAtom } from "jotai";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getOramaDb } from "@/lib/search";
 import { detectLanguage } from "@/lib/utils";
 
@@ -212,10 +212,10 @@ export const useInfiniteScroll = (
     );
   }, [offset, setHits, search]);
 
-  // Triggers when search params change,
-  // resetting the pagination
-  useEffect(() => {
-    const { hits, ...metadata } = search(
+  const lastSearchedKeyRef = useRef<string | null>(null);
+
+  const runSearch = useCallback(() => {
+    const { hits: newHits, ...metadata } = search(
       {
         sortBy,
         term: params.term,
@@ -226,10 +226,33 @@ export const useInfiniteScroll = (
     );
 
     setOffset(0);
-    setHits(hits);
+    setHits(newHits);
     setSearchResultsMetadata({ ...metadata, searchTerm: params.term });
-    setHasMore(hits.length < metadata.count);
-  }, [paramsKey, setOffset, setHits, setSearchResultsMetadata, search]);
+    setHasMore(newHits.length < metadata.count);
+  }, [
+    search,
+    sortBy,
+    params.term,
+    whereFilter,
+    searchQueryLanguage,
+    setOffset,
+    setHits,
+    setSearchResultsMetadata,
+  ]);
+
+  // Search when the params change, or when the shared results cache is reset to
+  // null from elsewhere (e.g. grading a card closes the flashcard drawer and
+  // calls reset()). Without the null case the list would sit empty forever,
+  // since nothing else re-runs the search on the same route. An empty result is
+  // stored as [] (not null), so a genuinely empty dictionary doesn't re-loop.
+  useEffect(() => {
+    const paramsChanged = lastSearchedKeyRef.current !== paramsKey;
+    const wasReset = hits === null;
+    if (!(paramsChanged || wasReset)) return;
+
+    lastSearchedKeyRef.current = paramsKey;
+    runSearch();
+  }, [paramsKey, hits, runSearch]);
 
   useEffect(() => {
     if (!(hits && searchResultsMetadata)) return;


### PR DESCRIPTION
## Symptom
On web, after reviewing a flashcard, the home page search results flip to "loading" and stay empty indefinitely.

## Cause
Regression from #77. Grading closes the flashcard drawer, which calls `reset()` to refresh the sorted list. `reset()` nulls the shared results atom — but web's `useInfiniteScroll` only re-runs its search on a **params change**; nothing re-searched when `hits` went `null` on the same route. So the list emptied and never repopulated.

(Add/edit word never hit this because they navigate away and back, which changes the params and triggers a search. The drawer closes on the same route, so it was exposed.)

## Fix
Drive the search from a single effect that runs when **either** the params change **or** the cache was reset to `null`:
- Tracks the last-searched params key in a ref to avoid a double-search on mount.
- Empty results are stored as `[]` (not `null`), so a genuinely empty dictionary doesn't re-loop.
- A failed search leaves `hits` `null` without re-running (effect deps are unchanged), so no infinite loop.

Mirrors the equivalent mobile behavior (mobile already re-searches on `hits === null`).

## Test plan
- [ ] Review a card, close the drawer → home list repopulates (re-sorted), not stuck empty
- [ ] Sort/filter/search still work and paginate (show more)
- [ ] Add / edit / delete word still refresh the list
- [ ] Empty dictionary shows the empty state, not an infinite loading spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result updates when search criteria change.
  * Restored initial search results when cached results are cleared.
  * Improved pagination handling to keep result counts and loading state accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->