### PR TITLE
fix(web): keep a revealed API key inside its dialog

### DIFF
--- a/apps/web/src/components/features/settings/ApiKeysCardSection.tsx
+++ b/apps/web/src/components/features/settings/ApiKeysCardSection.tsx
@@ -288,13 +288,19 @@ const CreatedKeyDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center gap-x-2">
-          <code className="min-w-0 flex-1 overflow-x-auto rounded-md bg-muted px-3 py-2 font-mono text-sm">
+        {/* The key is one long unbreakable token. It has to wrap rather than
+            scroll or the user can only ever see part of it, and `min-w-0` is
+            needed on the row too: DialogContent lays its children out in a
+            grid, whose items refuse to shrink below their content by default
+            and so push the whole dialog wider than its max-width. */}
+        <div className="flex min-w-0 items-start gap-x-2">
+          <code className="min-w-0 flex-1 break-all rounded-md bg-muted px-3 py-2 font-mono text-sm">
             {apiKey}
           </code>
 
           <Button
             aria-label={t`Copy API key`}
+            className="shrink-0"
             onClick={copyKey}
             size="icon"
             variant="outline"


### PR DESCRIPTION
## Problem

The dialog that shows a newly created API key rendered the key in a single-line
`overflow-x-auto` box. The key ran past the edge of the modal and dragged the surrounding
text out with it.

Two things compounding:

- An API key is one long token with nothing to break on, so scrolling means the user only
  ever sees a fragment of the credential they're supposed to copy.
- The row holding it had no `min-w-0`. `DialogContent` lays its children out in a `grid`, and
  a grid item won't shrink below its content by default — so rather than the box constraining
  the key, the key stretched the row and pushed the whole dialog past its `max-w`, which is
  why the description text appeared to overflow too.

## Change

Wrap instead of scroll, and let the row shrink:

```diff
-<div className="flex items-center gap-x-2">
-  <code className="min-w-0 flex-1 overflow-x-auto rounded-md bg-muted px-3 py-2 font-mono text-sm">
+<div className="flex min-w-0 items-start gap-x-2">
+  <code className="min-w-0 flex-1 break-all rounded-md bg-muted px-3 py-2 font-mono text-sm">
```

Plus `shrink-0` on the copy button so it can't be squeezed, and `items-start` so it stays
aligned to the first line once the key wraps.

The key now renders as two or three wrapped lines inside the dialog instead of a clipped
single line.

## Testing

**Not verified visually.** No dev stack was running where this was written, and web has no
component-test infrastructure to assert layout, so this is a reasoned CSS fix rather than an
observed one. Worth a quick look at Settings → API keys → Create key before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
