### PR TITLE
fix(search): stop building sort indexes for string fields

### DIFF
--- a/packages/search/src/database.ts
+++ b/packages/search/src/database.ts
@@ -43,12 +43,36 @@ const formatElapsedTime = (number: bigint): string | number | object => {
 };
 
 /**
+ * The only properties the app ever sorts by. Everything else in the schema is
+ * declared unsortable below.
+ */
+export const SORTABLE_PROPERTIES = [
+  "created_at_timestamp_ms",
+  "updated_at_timestamp_ms",
+  "max_difficulty",
+  "last_review_timestamp_ms",
+] as const satisfies readonly (keyof typeof dictionarySchema)[];
+
+// Orama builds a sort index per sortable property and re-sorts ALL of them
+// lazily on the first sorted query after any insert. String properties sort via
+// localeCompare, which on Hermes bridges to the platform collator once per
+// comparison -- that turned a ~20ms re-sort on web into ~7s on mobile. Sorting
+// is never offered on these fields, so the indexes are pure cost.
+const UNSORTABLE_PROPERTIES = Object.keys(dictionarySchema).filter(
+  (property) =>
+    !SORTABLE_PROPERTIES.includes(
+      property as (typeof SORTABLE_PROPERTIES)[number]
+    )
+);
+
+/**
  * Creates a new Orama database instance for dictionary search
  */
 export const createDictionaryDatabase = (): DictionaryOrama => {
   return create({
     schema: dictionarySchema,
     plugins: [pluginQPS()],
+    sort: { unsortableProperties: UNSORTABLE_PROPERTIES },
     components: {
       tokenizer: multiLanguageTokenizer,
       formatElapsedTime,


### PR DESCRIPTION
Picking a sort in the mobile dictionary filters froze the UI for ~7s. Orama keeps one sort index per sortable schema property and lazily re-sorts *all* of them on the first sorted query after any insert, so the cost is paid on the first sort after an index build, and again after every word edit or flashcard grade.

The dictionary schema declared 10 sortable properties, 6 of them strings. String sort indexes compare with localeCompare, which Hermes implements by bridging to the platform collator once per comparison. The app only ever sorts by the 4 numeric properties (created/updated timestamps, max difficulty, last review), so the 6 string indexes were pure cost. Declaring them unsortable removes the collation work entirely.

Web ran the same code path and paid the same penalty, but V8 does the whole re-sort in ~20ms, so it was never noticeable there.

Note this turns an unsupported sort property from a slow query into a thrown UNABLE_TO_SORT_ON_UNKNOWN_FIELD; the two SORT_MAPs in apps/web and apps/mobile only reference the 4 numeric properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dictionary search efficiency by limiting sorting support to relevant fields.
  * Preserved sorting behavior for supported dictionary properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->