### PR TITLE
fix(search): type sort maps against the sortable properties

### DIFF
--- a/apps/mobile/src/hooks/useSearch.ts
+++ b/apps/mobile/src/hooks/useSearch.ts
@@ -9,6 +9,7 @@ import type { WordType } from "@bahar/drizzle-user-db-schemas";
 import { detectLanguage } from "@bahar/search/arabic";
 import {
   type SearchDictionaryOptions,
+  type SortableProperty,
   searchDictionary,
 } from "@bahar/search/database";
 import type { DictionaryDocument } from "@bahar/search/schema";
@@ -37,7 +38,12 @@ type SearchResultsMetadata = Omit<SearchResults, "hits"> & {
   searchTerm?: string;
 };
 
-const SORT_MAP: Record<string, { property: string; order: "ASC" | "DESC" }> = {
+// Typed against SortableProperty because Orama only builds sort indexes for
+// those properties and throws on anything else at query time.
+const SORT_MAP: Record<
+  Exclude<SortOption, "relevance">,
+  { property: SortableProperty; order: "ASC" | "DESC" }
+> = {
   createdAt: { property: "created_at_timestamp_ms", order: "DESC" },
   updatedAt: { property: "updated_at_timestamp_ms", order: "DESC" },
   difficulty: { property: "max_difficulty", order: "DESC" },

--- a/apps/web/src/hooks/search/useSearch.ts
+++ b/apps/web/src/hooks/search/useSearch.ts
@@ -2,6 +2,7 @@ import type { WordType } from "@bahar/drizzle-user-db-schemas";
 import {
   type SearchDictionaryOptions,
   type SearchLanguage,
+  type SortableProperty,
   searchDictionary,
 } from "@bahar/search/database";
 import type { DictionaryDocument } from "@bahar/search/schema";
@@ -18,6 +19,9 @@ export const SORT_OPTIONS = [
   "difficulty",
   "lastReviewed",
 ] as const;
+
+type SortOption = (typeof SORT_OPTIONS)[number];
+
 const SEARCH_RESULTS_PER_PAGE = 20;
 
 const searchResultsMetadataAtom = atom<
@@ -133,7 +137,7 @@ export const useInfiniteScroll = (
       tags?: string[];
       types?: WordType[];
     };
-    sort?: (typeof SORT_OPTIONS)[number];
+    sort?: SortOption;
   } = {}
 ) => {
   const { search } = useSearch();
@@ -162,16 +166,20 @@ export const useInfiniteScroll = (
   const sortBy = useMemo<SearchDictionaryOptions["sortBy"]>(() => {
     if (!params.sort || params.sort === "relevance") return undefined;
 
-    const sortMap: Record<string, { property: string; order: "ASC" | "DESC" }> =
-      {
-        createdAt: { property: "created_at_timestamp_ms", order: "DESC" },
-        updatedAt: { property: "updated_at_timestamp_ms", order: "DESC" },
-        difficulty: { property: "max_difficulty", order: "DESC" },
-        lastReviewed: {
-          property: "last_review_timestamp_ms",
-          order: "DESC",
-        },
-      };
+    // Typed against SortableProperty because Orama only builds sort indexes for
+    // those properties and throws on anything else at query time.
+    const sortMap: Record<
+      Exclude<SortOption, "relevance">,
+      { property: SortableProperty; order: "ASC" | "DESC" }
+    > = {
+      createdAt: { property: "created_at_timestamp_ms", order: "DESC" },
+      updatedAt: { property: "updated_at_timestamp_ms", order: "DESC" },
+      difficulty: { property: "max_difficulty", order: "DESC" },
+      lastReviewed: {
+        property: "last_review_timestamp_ms",
+        order: "DESC",
+      },
+    };
 
     return sortMap[params.sort];
   }, [paramsKey]);

--- a/packages/search/src/database.ts
+++ b/packages/search/src/database.ts
@@ -53,16 +53,19 @@ export const SORTABLE_PROPERTIES = [
   "last_review_timestamp_ms",
 ] as const satisfies readonly (keyof typeof dictionarySchema)[];
 
+/**
+ * Sorting by anything outside this union throws at query time, so callers
+ * mapping a UI sort option to an Orama property should type against it.
+ */
+export type SortableProperty = (typeof SORTABLE_PROPERTIES)[number];
+
 // Orama builds a sort index per sortable property and re-sorts ALL of them
 // lazily on the first sorted query after any insert. String properties sort via
 // localeCompare, which on Hermes bridges to the platform collator once per
 // comparison -- that turned a ~20ms re-sort on web into ~7s on mobile. Sorting
 // is never offered on these fields, so the indexes are pure cost.
 const UNSORTABLE_PROPERTIES = Object.keys(dictionarySchema).filter(
-  (property) =>
-    !SORTABLE_PROPERTIES.includes(
-      property as (typeof SORTABLE_PROPERTIES)[number]
-    )
+  (property) => !SORTABLE_PROPERTIES.includes(property as SortableProperty)
 );
 
 /**


### PR DESCRIPTION
## Problem

`createDictionaryDatabase` now declares every non-numeric schema property unsortable (#82), so Orama only builds sort indexes for the 4 numeric ones. Passing anything else as a sort property throws `UNABLE_TO_SORT_ON_UNKNOWN_FIELD` at query time — on mobile that lands in `Sentry.captureException` inside `performSearch` and the list silently renders nothing.

Both `SORT_MAP`s were typed `Record<string, { property: string; order: "ASC" | "DESC" }>`, which caught neither failure mode:

1. A typo in a property name — now a runtime throw instead of just a slow query.
2. A sort option declared in `SORT_OPTIONS` but missing from the map — `SORT_MAP[params.sort]` returns `undefined`, `sortBy` goes unset, and the sort is silently ignored. This hole predates #82.

## Change

Exports a `SortableProperty` union from `@bahar/search/database` (derived from the existing `SORTABLE_PROPERTIES` constant) and keys both maps on `Exclude<SortOption, "relevance">` with `property: SortableProperty`. Both mistakes become compile errors.

Incidental tidies in `apps/web/src/hooks/search/useSearch.ts`: added a local `SortOption` alias (mobile already exported one) and pointed `useInfiniteScroll`'s `sort?` param at it instead of a repeated `(typeof SORT_OPTIONS)[number]`.

## Verification

Temporarily broke each map to confirm the guard fires:

\`\`\`
mobile  TS2820: Type '"last_review_timestamp"' is not assignable to type
        '"created_at_timestamp_ms" | ... | "max_difficulty"'.
        Did you mean '"last_review_timestamp_ms"'?
web     TS2741: Property 'difficulty' is missing in type '{...}' but required in
        type 'Record<"createdAt" | "updatedAt" | "difficulty" | "lastReviewed", ...>'
\`\`\`

Restored, then: biome clean, `tsc --noEmit` zero errors in the touched files on both apps (the repo's pre-existing errors elsewhere are unchanged), mobile jest 14 passed.

## Risk

Types only — no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)