### PR TITLE
fix(mobile): collapse the footer safe area while the keyboard is open

### DIFF
--- a/apps/mobile/src/app/(search)/(home)/add-word.tsx
+++ b/apps/mobile/src/app/(search)/(home)/add-word.tsx
@@ -12,7 +12,10 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
+  useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
 import { z } from "zod";
 import {
@@ -45,6 +48,8 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
+
+const FOOTER_BOTTOM_PADDING = 12;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -90,6 +95,16 @@ export default function AddWordScreen() {
   const [createMultiple, setCreateMultiple] = useAtom(createMultipleAtom);
   const colors = useThemeColors();
   const shouldResetFormRef = useRef(false);
+  const insets = useSafeAreaInsets();
+  const { progress: keyboardProgress } = useReanimatedKeyboardAnimation();
+
+  // The keyboard covers the home indicator, so the safe area inset is dead
+  // space while it is open. Collapse it on the same clock the sticky view
+  // uses so the footer shrinks in step with the keyboard.
+  const footerStyle = useAnimatedStyle(() => ({
+    paddingBottom:
+      FOOTER_BOTTOM_PADDING + insets.bottom * (1 - keyboardProgress.value),
+  }));
 
   const { data: settingsData } = useQuery({
     queryFn: settingsTable.getSettings.query,
@@ -292,7 +307,10 @@ export default function AddWordScreen() {
         </KeyboardAwareScrollView>
 
         <KeyboardStickyView>
-          <View className="gap-3 border-border border-t bg-background px-4 pt-3 pb-safe-offset-3">
+          <Animated.View
+            className="gap-3 border-border border-t bg-background px-4 pt-3"
+            style={footerStyle}
+          >
             <View className="flex-row items-center gap-2 self-center">
               <Pressable
                 className="flex-row items-center gap-2"
@@ -335,7 +353,7 @@ export default function AddWordScreen() {
                 )}
               </Button>
             </View>
-          </View>
+          </Animated.View>
         </KeyboardStickyView>
       </View>
     </FormProvider>

--- a/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
+++ b/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
@@ -17,7 +17,10 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
+  useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
 import { z } from "zod";
 import {
@@ -44,6 +47,8 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
+
+const FOOTER_BOTTOM_PADDING = 12;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -88,6 +93,16 @@ export default function EditWordScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { scrollHandler } = useCollapsibleHeader(t`Edit word`);
   const { reset: resetSearch } = useSearch();
+  const insets = useSafeAreaInsets();
+  const { progress: keyboardProgress } = useReanimatedKeyboardAnimation();
+
+  // The keyboard covers the home indicator, so the safe area inset is dead
+  // space while it is open. Collapse it on the same clock the sticky view
+  // uses so the footer shrinks in step with the keyboard.
+  const footerStyle = useAnimatedStyle(() => ({
+    paddingBottom:
+      FOOTER_BOTTOM_PADDING + insets.bottom * (1 - keyboardProgress.value),
+  }));
 
   const {
     data: entry,
@@ -427,7 +442,10 @@ export default function EditWordScreen() {
         </KeyboardAwareScrollView>
 
         <KeyboardStickyView>
-          <View className="flex-row items-center justify-center gap-3 border-border border-t bg-background px-4 pt-3 pb-safe-offset-3">
+          <Animated.View
+            className="flex-row items-center justify-center gap-3 border-border border-t bg-background px-4 pt-3"
+            style={footerStyle}
+          >
             <Button onPress={() => router.back()} variant="outline">
               <Trans>Cancel</Trans>
             </Button>
@@ -442,7 +460,7 @@ export default function EditWordScreen() {
                 <Trans>Save changes</Trans>
               )}
             </Button>
-          </View>
+          </Animated.View>
         </KeyboardStickyView>
       </View>
     </FormProvider>


### PR DESCRIPTION
## Problem

The sticky Cancel/Save footer on the mobile add-word and edit-word screens used a static `pb-safe-offset-3` (bottom safe area inset + 12pt). `KeyboardStickyView` only translates the footer up by the keyboard height — it doesn't change the footer's own padding. So when the keyboard opened, the safe area inset (~34pt on notched iPhones) rode along as visible dead space between the buttons and the top of the keyboard, pushing the buttons noticeably too far up.

The inset exists to clear the home indicator. The keyboard already covers it, so while the keyboard is open the inset is pure waste.

## Change

Footer `View` → `Animated.View` with `paddingBottom` driven off `useReanimatedKeyboardAnimation().progress`:

```
paddingBottom = 12 + insets.bottom * (1 - progress)
```

Keyboard closed → `12 + insets.bottom` (identical to the old `pb-safe-offset-3`). Keyboard open → a flat 12pt. Applied to both screens.

## Why this way

The alternative was `KeyboardStickyView offset={{ opened: insets.bottom }}`, a one-liner that pushes the footer back down so the padded strip slides *under* the keyboard. That hides the dead space rather than removing it — the footer stays tall and keeps occupying that much of the screen. Animating the padding actually shrinks the footer and returns the space to the scroll view.

`progress` is the same shared value `KeyboardStickyView` interpolates its own `translateY` from, so the shrink and the translate run on one clock rather than two independently-timed animations.

## Review notes

- **Not yet verified on a device.** Worth eyeballing on a notched iPhone to confirm there's no one-frame jump at keyboard-open: the translate and the padding read the same `progress` value but are applied as separate animated styles.
- `bottomOffset={90}` on `KeyboardAwareScrollView` is still hardcoded in both files and left alone. The footer height now varies with keyboard state, so 90 is a guess in both states. Fixing it properly needs an `onLayout` measurement — left as follow-up rather than widening this fix.
- `FOOTER_BOTTOM_PADDING` and the `useAnimatedStyle` block are duplicated across the two files. The two footers differ (add-word has an extra "Create multiple" row), so extracting a shared footer component is a larger refactor and also left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved footer behavior on add-word and edit-word screens when the on-screen keyboard opens or closes.
  * Footer spacing now adjusts smoothly for keyboard movement and device safe areas, keeping actions visible and properly positioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->