### PR TITLE
fix(mobile): offset the sticky footer by the bottom inset, not animated padding

### DIFF
--- a/apps/mobile/src/app/(search)/(home)/add-word.tsx
+++ b/apps/mobile/src/app/(search)/(home)/add-word.tsx
@@ -12,9 +12,7 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
-  useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
-import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
 import { z } from "zod";
@@ -48,8 +46,6 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
-
-const FOOTER_BOTTOM_PADDING = 12;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -96,15 +92,6 @@ export default function AddWordScreen() {
   const colors = useThemeColors();
   const shouldResetFormRef = useRef(false);
   const insets = useSafeAreaInsets();
-  const { progress: keyboardProgress } = useReanimatedKeyboardAnimation();
-
-  // The keyboard covers the home indicator, so the safe area inset is dead
-  // space while it is open. Collapse it on the same clock the sticky view
-  // uses so the footer shrinks in step with the keyboard.
-  const footerStyle = useAnimatedStyle(() => ({
-    paddingBottom:
-      FOOTER_BOTTOM_PADDING + insets.bottom * (1 - keyboardProgress.value),
-  }));
 
   const { data: settingsData } = useQuery({
     queryFn: settingsTable.getSettings.query,
@@ -306,11 +293,12 @@ export default function AddWordScreen() {
           </View>
         </KeyboardAwareScrollView>
 
-        <KeyboardStickyView>
-          <Animated.View
-            className="gap-3 border-border border-t bg-background px-4 pt-3"
-            style={footerStyle}
-          >
+        {/* The keyboard covers the home indicator, so the bottom safe area
+            inset is dead space while it is open. Offsetting the sticky view
+            back down by the inset slides that padding under the keyboard
+            instead of leaving it as a visible gap above it. */}
+        <KeyboardStickyView offset={{ opened: insets.bottom }}>
+          <View className="gap-3 border-border border-t bg-background px-4 pt-3 pb-safe-offset-3">
             <View className="flex-row items-center gap-2 self-center">
               <Pressable
                 className="flex-row items-center gap-2"
@@ -353,7 +341,7 @@ export default function AddWordScreen() {
                 )}
               </Button>
             </View>
-          </Animated.View>
+          </View>
         </KeyboardStickyView>
       </View>
     </FormProvider>

--- a/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
+++ b/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
@@ -17,9 +17,7 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
-  useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
-import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
 import { z } from "zod";
@@ -47,8 +45,6 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
-
-const FOOTER_BOTTOM_PADDING = 12;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -94,15 +90,6 @@ export default function EditWordScreen() {
   const { scrollHandler } = useCollapsibleHeader(t`Edit word`);
   const { reset: resetSearch } = useSearch();
   const insets = useSafeAreaInsets();
-  const { progress: keyboardProgress } = useReanimatedKeyboardAnimation();
-
-  // The keyboard covers the home indicator, so the safe area inset is dead
-  // space while it is open. Collapse it on the same clock the sticky view
-  // uses so the footer shrinks in step with the keyboard.
-  const footerStyle = useAnimatedStyle(() => ({
-    paddingBottom:
-      FOOTER_BOTTOM_PADDING + insets.bottom * (1 - keyboardProgress.value),
-  }));
 
   const {
     data: entry,
@@ -441,11 +428,12 @@ export default function EditWordScreen() {
           </View>
         </KeyboardAwareScrollView>
 
-        <KeyboardStickyView>
-          <Animated.View
-            className="flex-row items-center justify-center gap-3 border-border border-t bg-background px-4 pt-3"
-            style={footerStyle}
-          >
+        {/* The keyboard covers the home indicator, so the bottom safe area
+            inset is dead space while it is open. Offsetting the sticky view
+            back down by the inset slides that padding under the keyboard
+            instead of leaving it as a visible gap above it. */}
+        <KeyboardStickyView offset={{ opened: insets.bottom }}>
+          <View className="flex-row items-center justify-center gap-3 border-border border-t bg-background px-4 pt-3 pb-safe-offset-3">
             <Button onPress={() => router.back()} variant="outline">
               <Trans>Cancel</Trans>
             </Button>
@@ -460,7 +448,7 @@ export default function EditWordScreen() {
                 <Trans>Save changes</Trans>
               )}
             </Button>
-          </Animated.View>
+          </View>
         </KeyboardStickyView>
       </View>
     </FormProvider>


### PR DESCRIPTION
Follow-up to #84, which did not actually fix the bug on Android. Replaces that approach.

## Problem

The sticky Cancel/Save footer on the mobile add-word and edit-word screens sits too far above the keyboard when a text input is focused. #84 tried to fix this by animating the footer's `paddingBottom` off `useReanimatedKeyboardAnimation().progress`, collapsing the bottom safe-area inset while the keyboard is open. The gap was still there.

Two things were wrong with that.

**It mixed animation systems.** `KeyboardStickyView` in `react-native-keyboard-controller` 1.18.5 is built on RN `Animated` (`useKeyboardAnimation`), not Reanimated. A Reanimated-driven padding is on a different clock than the component's own `translateY`, so the comment in #84 claiming they shared one clock was false.

**The inset never needed animating.** The gap comes from how the keyboard height is reported on Android. In `KeyboardAnimationCallback.getCurrentKeyboardHeight()`:

```kotlin
val keyboardHeight = insets.getInsets(Type.ime()).bottom
val navigationBar = if (config.hasTranslucentNavigationBar) 0
                    else insets.getInsets(Type.navigationBars()).bottom
return (keyboardHeight - navigationBar).dp.coerceAtLeast(0.0)
```

`KeyboardProvider` passes `navigationBarTranslucent={IS_EDGE_TO_EDGE || navigationBarTranslucent}`, and Expo SDK 54 turns Android edge-to-edge on by default. So `hasTranslucentNavigationBar` is true, the navigation bar is *not* subtracted, and the reported keyboard height is the full IME inset — measured from the window bottom, including the navigation bar strip.

Meanwhile edge-to-edge puts the footer's bottom edge at the window bottom, under the nav bar, with `pb-safe-offset-3` holding the buttons `insets.bottom + 12` above that edge. Translating up by the full IME inset lands the footer's bottom edge on the keyboard's top edge, so those `insets.bottom + 12` become a visible gap above the keyboard.

## Change

Drop the animated padding, restore the static `pb-safe-offset-3`, and cancel the inset term via the sticky view's own offset:

```tsx
<KeyboardStickyView offset={{ opened: insets.bottom }}>
```

`offset` feeds the `translateY` the component already computes — `translateY = height + interpolate(progress, [closed, opened])` — so this is one value on one animation system, transform only, no layout animation. The safe-area padding slides under the keyboard and the buttons sit 12pt above it. Keyboard closed is unchanged.

The same geometry applies on iOS, where the keyboard covers the home indicator, so this is not an Android-only fix.

## Review notes

- **Verified by reading the native source and doing the geometry, not on a device.** Reproduced and reported on Android; iOS untested.
- **Unresolved:** why #84's animated padding had no effect. By this same geometry, shrinking the padding to 12 should also have removed the gap. Reanimated's docs do animate layout props, so "layout props don't commit on Fabric" is a guess, not a conclusion. The likeliest remaining suspect is uniwind's `className`→`style` handling clobbering an animated `paddingBottom` on `Animated.View`. This PR sidesteps the question rather than answering it; worth knowing if we ever want to animate a layout prop on a `className`'d component elsewhere.
- **Known risk:** this assumes `useSafeAreaInsets().bottom` stays at the nav-bar height while the keyboard is open. If safe-area-context grows `bottom` toward the IME height on some Android version, the offset over-pushes and the footer ends up partly behind the keyboard. Fix in that case would be to capture the inset while the keyboard is closed instead of reading it live.
- `bottomOffset={90}` on `KeyboardAwareScrollView` is still hardcoded in both files, unchanged from #84. Wants an `onLayout` measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)