### PR TITLE
fix(api): mint read-only db tokens without the SDK

### DIFF
--- a/apps/api/src/clients/turso.ts
+++ b/apps/api/src/clients/turso.ts
@@ -1,6 +1,7 @@
 import { createClient as createDbClient } from "@libsql/client";
 import { createClient as createPlatformClient } from "@tursodatabase/api";
 import { asc, eq, gt } from "drizzle-orm";
+import { decodeJwt } from "jose";
 import { customAlphabet } from "nanoid";
 import { db as centralDb } from "../db";
 import { databases } from "../db/schema/databases";
@@ -17,6 +18,79 @@ export const tursoPlatformClient: ReturnType<typeof createPlatformClient> =
     token: config.TURSO_PLATFORM_API_KEY,
   }) as ReturnType<typeof createPlatformClient>;
 
+type TokenAuthorization = "full-access" | "read-only";
+
+/**
+ * Value of the `a` claim Turso puts on a database token for each authorization
+ * level. This claim is what the database enforces writes against.
+ */
+const TOKEN_AUTHORIZATION_CLAIM = {
+  "full-access": "rw",
+  "read-only": "ro",
+} as const;
+
+/**
+ * Mints a database token with a direct platform API call rather than through
+ * `@tursodatabase/api`.
+ *
+ * The SDK always sends a `permissions.read_attach` body, even when the caller
+ * asks for no permissions (its `createToken` defaults the database list to
+ * `[]`). A token minted with that body comes back carrying a `p` (permissions)
+ * claim and no `a` claim at all -- so `authorization=read-only` is silently
+ * dropped and the token can write. Sending no body, as the platform API docs
+ * do, yields `a: "ro"` and a token the database rejects writes on with
+ * "SQL write operations are forbidden".
+ */
+const mintDatabaseToken = async ({
+  dbName,
+  authorization,
+  expiration,
+}: {
+  dbName: string;
+  authorization: TokenAuthorization;
+  expiration: string;
+}): Promise<{ jwt: string }> => {
+  const url = new URL(
+    `/v1/organizations/${config.TURSO_ORG_SLUG}/databases/${dbName}/auth/tokens`,
+    "https://api.turso.tech"
+  );
+
+  url.searchParams.set("expiration", expiration);
+  url.searchParams.set("authorization", authorization);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${config.TURSO_PLATFORM_API_KEY}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to mint ${authorization} token for ${dbName}: ${response.status} ${await response.text()}`
+    );
+  }
+
+  const { jwt } = (await response.json()) as { jwt?: string };
+
+  if (!jwt) {
+    throw new Error(
+      `Turso returned no jwt for the ${authorization} token for ${dbName}`
+    );
+  }
+
+  const expectedClaim = TOKEN_AUTHORIZATION_CLAIM[authorization];
+  const { a: actualClaim } = decodeJwt(jwt);
+
+  // A token whose `a` claim doesn't match what we asked for isn't restricted
+  // the way callers are told it is, so refuse to hand it out at all.
+  if (actualClaim !== expectedClaim) {
+    throw new Error(
+      `Expected a "${expectedClaim}" token for ${dbName}, but Turso returned a token with a: ${JSON.stringify(actualClaim)}`
+    );
+  }
+
+  return { jwt };
+};
+
 /**
  * Creates a new access token for a user database. Defaults to full access with
  * a 2 week expiration -- what the apps hold, since they sync writes from a
@@ -28,6 +102,9 @@ export const tursoPlatformClient: ReturnType<typeof createPlatformClient> =
  * operations the apps use. Read-only tokens are minted per request rather than
  * stored, so they're kept shorter-lived -- but still comfortably longer than
  * the CLI's 24h cache refresh buffer, or every command would re-fetch one.
+ *
+ * Read-only tokens bypass `@tursodatabase/api`, which cannot mint one -- see
+ * {@link mintDatabaseToken}.
  */
 export const createUserAccessToken = async ({
   dbName,
@@ -35,9 +112,13 @@ export const createUserAccessToken = async ({
   expiration = "2w",
 }: {
   dbName: string;
-  authorization?: "full-access" | "read-only";
+  authorization?: TokenAuthorization;
   expiration?: string;
-}) => {
+}): Promise<{ jwt: string }> => {
+  if (authorization === "read-only") {
+    return mintDatabaseToken({ dbName, authorization, expiration });
+  }
+
   const accessToken = await tursoPlatformClient.databases.createToken(dbName, {
     authorization,
     expiration,


### PR DESCRIPTION
## Problem

`/databases/user` hands API-key callers (the CLI, and agents driving it) a token minted with `authorization: "read-only"`, on the premise that a leaked key can't corrupt data with raw SQL. That token was actually read-write. Confirmed against a real user database: an `INSERT` with it succeeded and the row persisted.

## Cause

`@tursodatabase/api` always sends a body on `createToken`, even when the caller asks for no permissions — its `read_attach` database list defaults to `[]`:

```js
body: JSON.stringify({
  permissions: { read_attach: { databases: options?.permissions?.read_attach?.databases ?? [] } },
})
```

Turso answers a request carrying that body with a token whose payload has a `p` (permissions) claim and **no `a` claim**. `a` is the claim the database enforces writes against, so `authorization=read-only` is silently dropped:

```
no body,     read-only:  {"a":"ro", "id":…, exp, iat, kid, rid}   -> writes blocked
no body,     full-access:{"a":"rw", "id":…, exp, iat, kid, rid}   -> writes allowed
SDK's body,  read-only:  {"p":{"ro":{"ns":[dbId]}}, exp, iat, …}   -> writes allowed
```

The platform API docs send no body, which is why `turso db tokens create --read-only` behaves correctly and our SDK call didn't. Latest SDK (2.0.5) still ships this, on both `databases.createToken` and `groups.createToken`, so upgrading isn't a fix. Related upstream report, different symptom from the same body: tursodatabase/turso-api-client-ts#30 — on newer `use_tursodb` databases Turso rejects the body outright with "Permissions are not supported for db-api controlled databases".

## Change

Read-only mints bypass the SDK: a plain `fetch` to `POST /v1/organizations/{org}/databases/{db}/auth/tokens?expiration=…&authorization=read-only` with no body. Full-access mints still use the SDK — its `p: {rw:…}` claim is harmless there, and that path is on the app sync critical path.

The new mint also decodes the returned JWT and throws unless the `a` claim matches the level requested. If the SDK's body ever comes back, or Turso changes the claim, the mint fails loudly rather than issuing a writable token labelled read-only.

## Testing

Called the real `createUserAccessToken({ authorization: "read-only" })` against a live user database:

```
claims: {"a":"ro"}          (no `p`)
select: count(*) = 7        reads fine
insert: BLOCKED -> "SQL write operations are forbidden
                    (current session doesn't have write permission)"
```

`tsc --noEmit` clean, `bun test` in `apps/api` 9 pass / 0 fail.

## Follow-up (not in this PR)

`apps/cli/src/lib/db-info-cache.ts` reuses a cached token based on expiry alone, so a CLI that already fetched a pre-fix full-access token keeps it for up to 2 weeks. Reuse should also require `access_level === "read_only"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating read-only database access tokens.
  * Access tokens are now validated to ensure they match the requested permission level.

* **Improvements**
  * Standardized access-token authorization options and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->