### PR TITLE
perf(mobile): move the header title to an atom so navigation doesn't stall

### DIFF
--- a/apps/mobile/src/app/(search)/_layout.tsx
+++ b/apps/mobile/src/app/(search)/_layout.tsx
@@ -18,7 +18,14 @@ import {
   PanelRight,
   Settings,
 } from "lucide-react-native";
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Text as RNText,
   TextInput,
@@ -46,6 +53,7 @@ import { performSync } from "@/lib/db/sync";
 import { rehydrateOramaDb, resetOramaDb } from "@/lib/search";
 import {
   dictionaryChangedAtom,
+  headerTitleAtom,
   isSyncingAtom,
   store,
   syncCompletedCountAtom,
@@ -75,13 +83,11 @@ function SearchBarHeader({
   searchQuery,
   onSearchChange,
   scrollY,
-  headerTitle,
 }: {
   navigation: DrawerNavigationProp<ParamListBase, string, undefined>;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   scrollY: SharedValue<number>;
-  headerTitle: string;
 }) {
   const pathname = usePathname();
   const { t } = useLingui();
@@ -89,6 +95,7 @@ function SearchBarHeader({
   const inputRef = useRef<TextInput>(null);
   const locales = useLocales();
   const insets = useSafeAreaInsets();
+  const headerTitle = useAtomValue(headerTitleAtom);
 
   const dir = locales[0].textDirection;
   const isAddWordPage = pathname.includes("add-word");
@@ -189,7 +196,6 @@ export default function Layout() {
   const locales = useLocales();
   const { t } = useLingui();
   const [searchQuery, setSearchQuery] = useState("");
-  const [headerTitle, setHeaderTitle] = useState("");
   const scrollY = useSharedValue(0);
   const syncCompletedCount = useAtomValue(syncCompletedCountAtom);
   const { refresh } = useSearch();
@@ -226,11 +232,10 @@ export default function Layout() {
   }, [syncCompletedCount, refresh]);
 
   const dir = locales[0].textDirection;
+  const headerScrollValue = useMemo(() => ({ scrollY }), [scrollY]);
 
   return (
-    <HeaderScrollContext.Provider
-      value={{ scrollY, headerTitle, setHeaderTitle }}
-    >
+    <HeaderScrollContext.Provider value={headerScrollValue}>
       <SearchContext.Provider value={{ searchQuery, setSearchQuery }}>
         <Drawer
           backBehavior="history"
@@ -250,10 +255,14 @@ export default function Layout() {
             // usePreloadDrawerScreens) and kept fully live — no freezeOnBlur —
             // so refocusing an already-visited screen doesn't pay an unfreeze
             // re-render. See also detachInactiveScreens on the navigator below.
+            //
+            // Because every screen stays live, anything that re-renders this
+            // layout re-renders all of them. Keep per-navigation state (like
+            // the header title) in atoms the consumer subscribes to directly,
+            // not in state here.
             drawerPosition: dir === "rtl" ? "right" : "left",
             header: ({ navigation }) => (
               <SearchBarHeader
-                headerTitle={headerTitle}
                 navigation={navigation}
                 onSearchChange={setSearchQuery}
                 scrollY={scrollY}

--- a/apps/mobile/src/contexts/header-scroll.ts
+++ b/apps/mobile/src/contexts/header-scroll.ts
@@ -3,8 +3,6 @@ import type { SharedValue } from "react-native-reanimated";
 
 interface HeaderScrollContextValue {
   scrollY: SharedValue<number>;
-  headerTitle: string;
-  setHeaderTitle: (title: string) => void;
 }
 
 export const HeaderScrollContext =

--- a/apps/mobile/src/hooks/useCollapsibleHeader.ts
+++ b/apps/mobile/src/hooks/useCollapsibleHeader.ts
@@ -1,10 +1,13 @@
 import { useFocusEffect } from "expo-router";
+import { useSetAtom } from "jotai";
 import { useCallback } from "react";
 import { useAnimatedScrollHandler } from "react-native-reanimated";
 import { useHeaderScroll } from "@/contexts/header-scroll";
+import { headerTitleAtom } from "@/lib/store";
 
 export function useCollapsibleHeader(title: string) {
-  const { scrollY, setHeaderTitle } = useHeaderScroll();
+  const { scrollY } = useHeaderScroll();
+  const setHeaderTitle = useSetAtom(headerTitleAtom);
 
   useFocusEffect(
     useCallback(() => {

--- a/apps/mobile/src/lib/store/index.ts
+++ b/apps/mobile/src/lib/store/index.ts
@@ -11,6 +11,16 @@ export const isSyncingAtom = atom(false);
 export const dictionaryChangedAtom = atom(false);
 
 /**
+ * Title shown in the drawer header, set by each screen on focus.
+ *
+ * An atom rather than context state: the drawer keeps every screen mounted and
+ * live (detachInactiveScreens={false}, no freezeOnBlur), so putting this in the
+ * layout's state made each focus/blur pair re-render all four screen subtrees
+ * and stall the navigation transition. Only the header subscribes here.
+ */
+export const headerTitleAtom = atom("");
+
+/**
  * Set when a flashcard is graded so the dictionary list refreshes its Orama
  * results the next time it regains focus. Grading updates the search index doc
  * directly; this defers the (sorted, full-index) re-search to when the list is


### PR DESCRIPTION
## Problem

Tapping a drawer item, or the Add word button, left the outgoing screen visible for a noticeable beat before the transition ran. It happened on every navigation, including drawer screens that `usePreloadDrawerScreens` had already preloaded — so it wasn't screen mount cost.

The drawer deliberately keeps all four screens mounted and live: `detachInactiveScreens={false}`, and no `freezeOnBlur`. The consequence, which the existing comments there didn't spell out, is that **anything re-rendering the `(search)` layout re-renders every screen subtree with it.**

`headerTitle` was `useState` in that layout, and `useCollapsibleHeader` writes it on both edges of a navigation:

```tsx
useFocusEffect(useCallback(() => {
  setHeaderTitle(title);            // focus
  scrollY.value = 0;
  return () => setHeaderTitle("");  // blur
}, [...]))
```

So one navigation = two layout re-renders, each cascading through four live screens on the JS thread before the transition could commit. `HeaderScrollContext`'s value was also an inline object literal, so every consumer re-rendered on each pass regardless of what changed.

The two optimizations meant to make navigation feel instant are what amplified a single state write into a four-screen re-render.

## Change

- New `headerTitleAtom` in `lib/store`; `SearchBarHeader` subscribes to it directly, so a title change re-renders the header alone
- `useCollapsibleHeader` writes via `useSetAtom` (stable setter, so the focus effect's identity is unchanged and it won't re-fire spuriously)
- `HeaderScrollContext` narrowed to just `scrollY`, a stable shared value, and its provider value memoized
- Comment added at `screenOptions` recording why per-navigation state must stay out of this component

This also aligns with `CLAUDE.md`'s "Prefer Jotai atoms over React Context" — the one place that broke that rule was the one stalling navigation.

## Review notes

- **Diagnosed by reading the code, not measured, and not verified on a device.** The mechanism accounts for every observed symptom (all navigations, preloaded screens included, outgoing screen holding rather than going blank, web unaffected), but no profile was captured. If the delay survives this, the clean way to rule the cascade in or out is to comment out both `setHeaderTitle` calls in `useCollapsibleHeader` and see whether it persists.
- **Same bug still present for `searchQuery`.** It remains layout state and `screenOptions.header` closes over it, so every keystroke in the search bar triggers the identical four-screen cascade. Different symptom (typing lag on home), left out to keep this reviewable.
- Two earlier hypotheses for this delay were wrong and are worth not re-treading: it is not add-word's form mount cost (preloaded screens are affected too), and it is not `ScreenFocusTransition`'s fade-from-zero (the outgoing screen stays visible, and stack pushes don't re-fire it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)