### PR TITLE
feat(mobile): make the screen focus transition perceptible on its own

### DIFF
--- a/apps/mobile/src/components/ScreenFocusTransition.tsx
+++ b/apps/mobile/src/components/ScreenFocusTransition.tsx
@@ -9,8 +9,13 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-const DURATION_MS = 180;
-const TRANSLATE_PX = 8;
+// Tuned to be perceptible on its own. Most drawer switches happen with the
+// drawer panel sliding closed over the top, which supplies plenty of motion and
+// hides this transition — but some navigations are programmatic (e.g. "View all
+// in dictionary" on the progress screen jumping to the sorted list) and this is
+// the only motion they get.
+const DURATION_MS = 240;
+const TRANSLATE_PX = 20;
 
 /**
  * Plays a short fade + upward slide whenever the wrapped screen gains focus.


### PR DESCRIPTION
## Problem

Tapping "View all in dictionary" on the progress screen (Difficult words card) jumps to the sorted dictionary with no visible motion. Drawer taps and opening the add/edit word screens both animate, so this one reads as a hard cut by comparison.

The other two get their motion from somewhere else entirely:

- **Drawer tap** — `@react-navigation/drawer` has no screen-swap animation. What you see is the drawer panel sliding closed, revealing the screen underneath.
- **Add/edit word** — native stack push with `animation: "slide_from_right"`.

"View all" is a programmatic `router.navigate` between two drawer siblings, so there's no panel to slide and no stack push. The only motion available is `ScreenFocusTransition` (applied to every drawer screen via the drawer's `screenLayout`), and at 180ms over 8px it was too subtle to register.

## Change

`components/ScreenFocusTransition.tsx`:

```
DURATION_MS  180 → 240
TRANSLATE_PX   8 → 20
```

Content slides 20px up while fading in over 240ms. Comment added recording why the values are what they are, since the reason is non-obvious: most drawer switches have the panel slide masking this transition, and the programmatic ones that don't are what set the floor for how visible it needs to be.

## Review notes

- **Applies to every drawer screen focus, not just this tap.** `screenLayout` is global, so there's no per-navigation override without introducing a signal the wrapper reads. Chosen deliberately over that: one file and two constants beats a new mechanism for a polish change.
- **This dial trades directly against #87**, which reduced perceived navigation latency. A longer focus transition adds some back on every drawer switch. 240ms should stay under the noticeable threshold, but if it feels sluggish, `DURATION_MS` is the knob — ~200ms while keeping the 20px slide.
- **Not verified on a device.** If "View all" still reads as an instant cut, then `ScreenFocusTransition` isn't firing on that navigation at all and the explanation above is wrong; the thing to check would be whether `useIsFocused()` actually flips for `(home)` on a programmatic `router.navigate` to a drawer sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined screen focus transitions with a longer duration and more pronounced movement.
  * Improved transition behavior for a smoother, more noticeable navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->