### PR TITLE
fix(mobile): pad the word form by the keyboard height so its tail stays reachable

### DIFF
--- a/apps/mobile/src/app/(search)/(home)/add-word.tsx
+++ b/apps/mobile/src/app/(search)/(home)/add-word.tsx
@@ -12,6 +12,7 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
+  useKeyboardState,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
@@ -46,6 +47,8 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
+
+const CONTENT_BOTTOM_PADDING = 24;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -92,6 +95,7 @@ export default function AddWordScreen() {
   const colors = useThemeColors();
   const shouldResetFormRef = useRef(false);
   const insets = useSafeAreaInsets();
+  const keyboardHeight = useKeyboardState((state) => state.height);
 
   const { data: settingsData } = useQuery({
     queryFn: settingsTable.getSettings.query,
@@ -228,7 +232,15 @@ export default function AddWordScreen() {
         <KeyboardAwareScrollView
           bottomOffset={90}
           className="flex-1"
-          contentContainerClassName="pb-6"
+          // KeyboardAwareScrollView already appends a keyboard-height spacer to
+          // make the tail of the form reachable, but it applies it through
+          // `useAnimatedStyle({ paddingBottom })`, which is a no-op in this app
+          // (see the same failure in #84). Without it the last sections can't be
+          // scrolled out from behind the keyboard, so pad by the real keyboard
+          // height here instead. Remove once the library's own spacer works.
+          contentContainerStyle={{
+            paddingBottom: CONTENT_BOTTOM_PADDING + keyboardHeight,
+          }}
           keyboardShouldPersistTaps="handled"
           onScroll={scrollHandler}
           scrollEventThrottle={16}

--- a/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
+++ b/apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx
@@ -17,6 +17,7 @@ import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import {
   KeyboardAwareScrollView,
   KeyboardStickyView,
+  useKeyboardState,
 } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { toast } from "sonner-native";
@@ -45,6 +46,8 @@ import { errorMap } from "@/utils/zod";
 z.config({ customError: errorMap });
 
 type FormData = z.infer<typeof FormSchema>;
+
+const CONTENT_BOTTOM_PADDING = 24;
 
 const Breadcrumbs = () => {
   const router = useRouter();
@@ -90,6 +93,7 @@ export default function EditWordScreen() {
   const { scrollHandler } = useCollapsibleHeader(t`Edit word`);
   const { reset: resetSearch } = useSearch();
   const insets = useSafeAreaInsets();
+  const keyboardHeight = useKeyboardState((state) => state.height);
 
   const {
     data: entry,
@@ -364,7 +368,15 @@ export default function EditWordScreen() {
         <KeyboardAwareScrollView
           bottomOffset={90}
           className="flex-1"
-          contentContainerClassName="pb-6"
+          // KeyboardAwareScrollView already appends a keyboard-height spacer to
+          // make the tail of the form reachable, but it applies it through
+          // `useAnimatedStyle({ paddingBottom })`, which is a no-op in this app
+          // (see the same failure in #84). Without it the last sections can't be
+          // scrolled out from behind the keyboard, so pad by the real keyboard
+          // height here instead. Remove once the library's own spacer works.
+          contentContainerStyle={{
+            paddingBottom: CONTENT_BOTTOM_PADDING + keyboardHeight,
+          }}
           keyboardShouldPersistTaps="handled"
           onScroll={scrollHandler}
           scrollEventThrottle={16}


### PR DESCRIPTION
## Problem

With the keyboard open on the add/edit word screens, the form can't be scrolled past Antonyms. Tags and Flashcards stay behind the keyboard with no way to reach them. Keyboard closed, everything is fine.

`KeyboardAwareScrollView` is supposed to prevent exactly this. It appends a spacer after its children, sized to the keyboard:

```js
const view = useAnimatedStyle(() => enabled ? {
  paddingBottom: currentKeyboardFrameHeight.value + 1
} : {}, [enabled]);
...
{children}
{enabled && <Reanimated.View style={view} />}
```

That spacer never materializes here — `useAnimatedStyle` returning a layout prop is a no-op in this app. Confirmed empirically: swapping the content padding for a large static value made the previously unreachable sections scroll into view, so the spacer is what's missing, not something clamping scroll.

## Change

Pad the content container by the real keyboard height instead of relying on the library's spacer:

```tsx
const keyboardHeight = useKeyboardState((state) => state.height);
// ...
contentContainerStyle={{ paddingBottom: CONTENT_BOTTOM_PADDING + keyboardHeight }}
```

Replaces `contentContainerClassName="pb-6"` in both files. The selector argument keeps this to one re-render per keyboard show/hide. The value is derived from the actual keyboard, not hardcoded, so it holds across devices, keyboard sizes, and orientations.

## Review notes

- **This is a workaround and the comment in the code says so.** Why animated layout props don't apply in this app is still unidentified. The same failure killed an earlier attempt to animate the sticky footer's padding (#84), and there is no working animated layout prop anywhere else in this codebase to compare against — so there's no evidence the mechanism has ever worked here.
- **Follow-up worth trying:** `react-native-keyboard-controller` is on 1.18.5, latest is 1.22.1, and the 1.22.x notes mention `KeyboardAwareScrollView` edge-case fixes. If an upgrade makes the library's own spacer work, this padding can be deleted. I did not find any release note naming Reanimated 4 or layout props, so it's worth trying rather than a known fix. It has native code, so it needs a fresh dev client build — which is why it wasn't bundled here.
- **Slight over-padding by design.** `state.height` is the full IME inset on Android edge-to-edge, while the footer sits in flow, so the strictly-needed amount is a bit less. Matches what the library itself intended (`keyboardHeight + 1`) and errs toward reachable.
- **No animation.** Padding changes on keyboard show/hide rather than tracking the keyboard frame-by-frame, so content settles in a step rather than gliding. Correctness over smoothness, given that animating it is the thing that doesn't work.
- `bottomOffset={90}` is still hardcoded in both files, unchanged. Separate issue, wants an `onLayout` measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)