### PR TITLE
Revert "feat(mobile): make the screen focus transition perceptible on its own"

### DIFF
--- a/apps/mobile/src/components/ScreenFocusTransition.tsx
+++ b/apps/mobile/src/components/ScreenFocusTransition.tsx
@@ -9,13 +9,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-// Tuned to be perceptible on its own. Most drawer switches happen with the
-// drawer panel sliding closed over the top, which supplies plenty of motion and
-// hides this transition — but some navigations are programmatic (e.g. "View all
-// in dictionary" on the progress screen jumping to the sorted list) and this is
-// the only motion they get.
-const DURATION_MS = 240;
-const TRANSLATE_PX = 20;
+const DURATION_MS = 180;
+const TRANSLATE_PX = 8;
 
 /**
  * Plays a short fade + upward slide whenever the wrapped screen gains focus.


### PR DESCRIPTION
Reverts #88.

## Why

#88 raised `ScreenFocusTransition` from 180ms/8px to 240ms/20px so that "View all in dictionary" on the progress screen would have visible motion. But `ScreenFocusTransition` is applied to every drawer screen through the drawer's `screenLayout`, so the change hit all four screens — and the added duration put perceived latency back into ordinary drawer navigation, which #87 had just removed. Not a good trade for one programmatic navigation.

Back to 180ms over 8px.

## Consequence

"View all in dictionary" reads as an instant cut again. Recorded here so the context isn't lost if it's revisited:

- `@react-navigation/drawer` has no screen-swap animation. Drawer taps look animated because the drawer *panel* slides closed to reveal the screen; add/edit word looks animated because it's a native stack push with `slide_from_right`.
- A programmatic jump between drawer siblings has neither, so `ScreenFocusTransition` is the only motion available — and at these values it isn't perceptible on its own.
- Solving it properly means a targeted animation for that one navigation (a per-navigation signal the wrapper reads to pick a variant), not retuning the shared wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)