### PR TITLE
feat(filters): add a match all/any toggle for tag filtering

### DIFF
--- a/apps/mobile/src/app/(search)/(home)/index.tsx
+++ b/apps/mobile/src/app/(search)/(home)/index.tsx
@@ -29,6 +29,7 @@ import {
   selectedTagsAtom,
   selectedTypesAtom,
   sortOptionAtom,
+  tagModeAtom,
 } from "@/lib/store/filters";
 import { useThemeColors } from "@/lib/theme";
 import { useSearchQuery } from "../_layout";
@@ -203,6 +204,7 @@ export default function HomeScreen() {
   const selectedTags = useAtomValue(selectedTagsAtom);
   const selectedTypes = useAtomValue(selectedTypesAtom);
   const sortOption = useAtomValue(sortOptionAtom);
+  const tagMode = useAtomValue(tagModeAtom);
   const { isAnonymous } = useUserPlan();
   const { state, error } = useAppInit();
 
@@ -305,6 +307,7 @@ export default function HomeScreen() {
         onTotalCountChange={handleTotalCountChange}
         searchQuery={deferredSearchQuery}
         sort={sortOption}
+        tagMode={tagMode}
         tags={selectedTags}
         types={selectedTypes}
       />

--- a/apps/mobile/src/app/(search)/decks/create.tsx
+++ b/apps/mobile/src/app/(search)/decks/create.tsx
@@ -170,30 +170,32 @@ export default function CreateDeckScreen() {
               </Text>
             </View>
             <View className="gap-2 px-4 pb-1">
-              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
-                {TAG_MODES.map((mode) => {
-                  const isSelected = tagMode === mode;
-                  return (
-                    <Pressable
-                      className={`flex-1 items-center rounded-md py-2 ${
-                        isSelected ? "bg-background" : ""
-                      }`}
-                      key={mode}
-                      onPress={() => setTagMode(mode)}
-                    >
-                      <Text
-                        className={`text-sm ${
-                          isSelected
-                            ? "font-semibold text-foreground"
-                            : "text-muted-foreground"
+              {tags.length >= 2 && (
+                <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                  {TAG_MODES.map((mode) => {
+                    const isSelected = tagMode === mode;
+                    return (
+                      <Pressable
+                        className={`flex-1 items-center rounded-md py-2 ${
+                          isSelected ? "bg-background" : ""
                         }`}
+                        key={mode}
+                        onPress={() => setTagMode(mode)}
                       >
-                        {tagModeLabels[mode]}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
+                        <Text
+                          className={`text-sm ${
+                            isSelected
+                              ? "font-semibold text-foreground"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          {tagModeLabels[mode]}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              )}
               <Text className="text-muted-foreground text-sm">
                 {tagMode === "all" ? (
                   <Trans>

--- a/apps/mobile/src/app/(search)/decks/create.tsx
+++ b/apps/mobile/src/app/(search)/decks/create.tsx
@@ -1,4 +1,9 @@
-import type { DeckFilters, WordType } from "@bahar/drizzle-user-db-schemas";
+import {
+  type DeckFilters,
+  TAG_MODES,
+  type TagMode,
+  type WordType,
+} from "@bahar/drizzle-user-db-schemas";
 import { t } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useMutation } from "@tanstack/react-query";
@@ -40,15 +45,25 @@ const useWordTypeLabels = (): Record<WordType, string> => {
   };
 };
 
+const useTagModeLabels = (): Record<TagMode, string> => {
+  const { t } = useLingui();
+  return {
+    all: t`Match all`,
+    any: t`Match any`,
+  };
+};
+
 export default function CreateDeckScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const { scrollHandler } = useCollapsibleHeader(t`Create a new deck`);
   const wordTypeLabels = useWordTypeLabels();
+  const tagModeLabels = useTagModeLabels();
 
   const [name, setName] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<WordType[]>([]);
   const [tags, setTags] = useState<{ name: string }[]>([]);
+  const [tagMode, setTagMode] = useState<TagMode>("all");
 
   const { mutateAsync: createDeck, isPending } = useMutation({
     mutationFn: decksTable.create.mutation,
@@ -72,7 +87,10 @@ export default function CreateDeckScreen() {
 
     const filters: DeckFilters = {};
     if (selectedTypes.length > 0) filters.types = selectedTypes;
-    if (tags.length > 0) filters.tags = tags.map((t) => t.name);
+    if (tags.length > 0) {
+      filters.tags = tags.map((t) => t.name);
+      filters.tagMode = tagMode;
+    }
 
     await createDeck({ deck: { name: name.trim(), filters } });
   };
@@ -150,8 +168,40 @@ export default function CreateDeckScreen() {
               <Text className="font-semibold text-base text-foreground">
                 <Trans>Tags</Trans>
               </Text>
+            </View>
+            <View className="gap-2 px-4 pb-1">
+              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                {TAG_MODES.map((mode) => {
+                  const isSelected = tagMode === mode;
+                  return (
+                    <Pressable
+                      className={`flex-1 items-center rounded-md py-2 ${
+                        isSelected ? "bg-background" : ""
+                      }`}
+                      key={mode}
+                      onPress={() => setTagMode(mode)}
+                    >
+                      <Text
+                        className={`text-sm ${
+                          isSelected
+                            ? "font-semibold text-foreground"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {tagModeLabels[mode]}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
               <Text className="text-muted-foreground text-sm">
-                <Trans>Words with any of these tags will be included</Trans>
+                {tagMode === "all" ? (
+                  <Trans>
+                    Only words with every one of these tags will be included
+                  </Trans>
+                ) : (
+                  <Trans>Words with any of these tags will be included</Trans>
+                )}
               </Text>
             </View>
             <View className="px-4 pt-2 pb-4">

--- a/apps/mobile/src/app/(search)/decks/create.tsx
+++ b/apps/mobile/src/app/(search)/decks/create.tsx
@@ -63,7 +63,7 @@ export default function CreateDeckScreen() {
   const [name, setName] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<WordType[]>([]);
   const [tags, setTags] = useState<{ name: string }[]>([]);
-  const [tagMode, setTagMode] = useState<TagMode>("all");
+  const [tagMode, setTagMode] = useState<TagMode>("any");
 
   const { mutateAsync: createDeck, isPending } = useMutation({
     mutationFn: decksTable.create.mutation,

--- a/apps/mobile/src/app/(search)/decks/edit/[id].tsx
+++ b/apps/mobile/src/app/(search)/decks/edit/[id].tsx
@@ -228,30 +228,32 @@ export default function EditDeckScreen() {
               </Text>
             </View>
             <View className="gap-2 px-4 pb-1">
-              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
-                {TAG_MODES.map((mode) => {
-                  const isSelected = tagMode === mode;
-                  return (
-                    <Pressable
-                      className={`flex-1 items-center rounded-md py-2 ${
-                        isSelected ? "bg-background" : ""
-                      }`}
-                      key={mode}
-                      onPress={() => setTagMode(mode)}
-                    >
-                      <Text
-                        className={`text-sm ${
-                          isSelected
-                            ? "font-semibold text-foreground"
-                            : "text-muted-foreground"
+              {tags.length >= 2 && (
+                <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                  {TAG_MODES.map((mode) => {
+                    const isSelected = tagMode === mode;
+                    return (
+                      <Pressable
+                        className={`flex-1 items-center rounded-md py-2 ${
+                          isSelected ? "bg-background" : ""
                         }`}
+                        key={mode}
+                        onPress={() => setTagMode(mode)}
                       >
-                        {tagModeLabels[mode]}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
+                        <Text
+                          className={`text-sm ${
+                            isSelected
+                              ? "font-semibold text-foreground"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          {tagModeLabels[mode]}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              )}
               <Text className="text-muted-foreground text-sm">
                 {tagMode === "all" ? (
                   <Trans>

--- a/apps/mobile/src/app/(search)/decks/edit/[id].tsx
+++ b/apps/mobile/src/app/(search)/decks/edit/[id].tsx
@@ -1,4 +1,9 @@
-import type { DeckFilters, WordType } from "@bahar/drizzle-user-db-schemas";
+import {
+  type DeckFilters,
+  TAG_MODES,
+  type TagMode,
+  type WordType,
+} from "@bahar/drizzle-user-db-schemas";
 import { t } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -41,12 +46,21 @@ const useWordTypeLabels = (): Record<WordType, string> => {
   };
 };
 
+const useTagModeLabels = (): Record<TagMode, string> => {
+  const { t } = useLingui();
+  return {
+    all: t`Match all`,
+    any: t`Match any`,
+  };
+};
+
 export default function EditDeckScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const { id } = useLocalSearchParams<{ id: string }>();
   const { scrollHandler } = useCollapsibleHeader(t`Edit deck`);
   const wordTypeLabels = useWordTypeLabels();
+  const tagModeLabels = useTagModeLabels();
 
   const { data: deck, status } = useQuery({
     queryFn: () => decksTable.get.query({ id }),
@@ -57,12 +71,16 @@ export default function EditDeckScreen() {
   const [name, setName] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<WordType[]>([]);
   const [tags, setTags] = useState<{ name: string }[]>([]);
+  const [tagMode, setTagMode] = useState<TagMode>("any");
 
   useEffect(() => {
     if (deck) {
       setName(deck.name);
       setSelectedTypes(deck.filters?.types ?? []);
       setTags((deck.filters?.tags ?? []).map((t) => ({ name: t })));
+      // Decks saved before tagMode existed were matched with "any", so the
+      // form opens on what the deck has actually been doing.
+      setTagMode(deck.filters?.tagMode ?? "any");
     }
   }, [deck]);
 
@@ -104,7 +122,10 @@ export default function EditDeckScreen() {
 
     const filters: DeckFilters = {};
     if (selectedTypes.length > 0) filters.types = selectedTypes;
-    if (tags.length > 0) filters.tags = tags.map((t) => t.name);
+    if (tags.length > 0) {
+      filters.tags = tags.map((t) => t.name);
+      filters.tagMode = tagMode;
+    }
 
     await updateDeck({ id, updates: { name: name.trim(), filters } });
   };
@@ -205,8 +226,40 @@ export default function EditDeckScreen() {
               <Text className="font-semibold text-base text-foreground">
                 <Trans>Tags</Trans>
               </Text>
+            </View>
+            <View className="gap-2 px-4 pb-1">
+              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                {TAG_MODES.map((mode) => {
+                  const isSelected = tagMode === mode;
+                  return (
+                    <Pressable
+                      className={`flex-1 items-center rounded-md py-2 ${
+                        isSelected ? "bg-background" : ""
+                      }`}
+                      key={mode}
+                      onPress={() => setTagMode(mode)}
+                    >
+                      <Text
+                        className={`text-sm ${
+                          isSelected
+                            ? "font-semibold text-foreground"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {tagModeLabels[mode]}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
               <Text className="text-muted-foreground text-sm">
-                <Trans>Words with any of these tags will be included</Trans>
+                {tagMode === "all" ? (
+                  <Trans>
+                    Only words with every one of these tags will be included
+                  </Trans>
+                ) : (
+                  <Trans>Words with any of these tags will be included</Trans>
+                )}
               </Text>
             </View>
             <View className="px-4 pt-2 pb-4">

--- a/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
@@ -1,4 +1,9 @@
-import { WORD_TYPES, type WordType } from "@bahar/drizzle-user-db-schemas";
+import {
+  TAG_MODES,
+  type TagMode,
+  WORD_TYPES,
+  type WordType,
+} from "@bahar/drizzle-user-db-schemas";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
@@ -38,6 +43,7 @@ import {
   selectedTagsAtom,
   selectedTypesAtom,
   sortOptionAtom,
+  tagModeAtom,
 } from "@/lib/store/filters";
 import { useThemeColors } from "@/lib/theme";
 import { Button } from "../ui/button";
@@ -70,6 +76,14 @@ const useWordTypeLabels = (): Record<WordType, string> => {
     "fi'l": t`Fi'l`,
     harf: t`Harf`,
     expression: t`Expression`,
+  };
+};
+
+const useTagModeLabels = (): Record<TagMode, string> => {
+  const { t } = useLingui();
+  return {
+    all: t`Match all`,
+    any: t`Match any`,
   };
 };
 
@@ -134,17 +148,21 @@ const FiltersModal: FC<{
   const { formatNumber } = useFormatNumber();
   const sortLabels = useSortLabels();
   const wordTypeLabels = useWordTypeLabels();
+  const tagModeLabels = useTagModeLabels();
 
   const appliedTags = useAtomValue(selectedTagsAtom);
   const appliedTypes = useAtomValue(selectedTypesAtom);
   const appliedSort = useAtomValue(sortOptionAtom);
+  const appliedTagMode = useAtomValue(tagModeAtom);
   const setAppliedTags = useSetAtom(selectedTagsAtom);
   const setAppliedTypes = useSetAtom(selectedTypesAtom);
   const setAppliedSort = useSetAtom(sortOptionAtom);
+  const setAppliedTagMode = useSetAtom(tagModeAtom);
 
   const [draftTags, setDraftTags] = useState<string[]>([]);
   const [draftTypes, setDraftTypes] = useState<WordType[]>([]);
   const [draftSort, setDraftSort] = useState<SortOption>("relevance");
+  const [draftTagMode, setDraftTagMode] = useState<TagMode>("all");
   const [tagSearch, setTagSearch] = useState("");
   const [expandedSection, setExpandedSection] = useState<
     "tags" | "types" | "sort" | null
@@ -156,6 +174,7 @@ const FiltersModal: FC<{
       setDraftTags(appliedTags);
       setDraftTypes(appliedTypes);
       setDraftSort(appliedSort);
+      setDraftTagMode(appliedTagMode);
       setTagSearch("");
       setExpandedSection("sort");
     }
@@ -188,27 +207,32 @@ const FiltersModal: FC<{
     setAppliedTags([]);
     setAppliedTypes([]);
     setAppliedSort("relevance");
+    setAppliedTagMode("all");
     setDraftTags([]);
     setDraftTypes([]);
     setDraftSort("relevance");
+    setDraftTagMode("all");
   };
 
   const handleApply = () => {
     setAppliedTags(draftTags);
     setAppliedTypes(draftTypes);
     setAppliedSort(draftSort);
+    setAppliedTagMode(draftTagMode);
     onClose();
   };
 
   const hasAppliedFilters =
     appliedTags.length > 0 ||
     appliedTypes.length > 0 ||
-    appliedSort !== "relevance";
+    appliedSort !== "relevance" ||
+    appliedTagMode !== "all";
 
   const hasDraftChanges =
     JSON.stringify(draftTags) !== JSON.stringify(appliedTags) ||
     JSON.stringify(draftTypes) !== JSON.stringify(appliedTypes) ||
-    draftSort !== appliedSort;
+    draftSort !== appliedSort ||
+    draftTagMode !== appliedTagMode;
 
   const tagsSummary =
     draftTags.length > 0
@@ -265,6 +289,43 @@ const FiltersModal: FC<{
             }
             summary={tagsSummary}
           >
+            {/* Above the picker so it reads as "match any of [these tags]",
+                and so the picker stays next to the list it drives. */}
+            <View className="gap-2 px-4 pb-3">
+              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                {TAG_MODES.map((mode) => {
+                  const isSelected = draftTagMode === mode;
+                  return (
+                    <Pressable
+                      className={`flex-1 items-center rounded-md py-2 ${
+                        isSelected ? "bg-background" : ""
+                      }`}
+                      key={mode}
+                      onPress={() => setDraftTagMode(mode)}
+                    >
+                      <Text
+                        className={`text-sm ${
+                          isSelected
+                            ? "font-semibold text-foreground"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {tagModeLabels[mode]}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <Text className="text-muted-foreground text-xs">
+                {draftTagMode === "all" ? (
+                  <Trans>Words must have every selected tag.</Trans>
+                ) : (
+                  <Trans>Words need only one of the selected tags.</Trans>
+                )}
+              </Text>
+            </View>
+
             <View className="px-4 pb-3">
               <TextInput
                 className="rounded-lg bg-muted/40 px-3 py-2.5 text-foreground text-sm"

--- a/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
@@ -290,42 +290,48 @@ const FiltersModal: FC<{
             }
             summary={tagsSummary}
           >
-            {/* Above the picker so it reads as "match any of [these tags]",
-                and so the picker stays next to the list it drives. */}
-            <View className="gap-2 px-4 pb-3">
-              <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
-                {TAG_MODES.map((mode) => {
-                  const isSelected = draftTagMode === mode;
-                  return (
-                    <Pressable
-                      className={`flex-1 items-center rounded-md py-2 ${
-                        isSelected ? "bg-background" : ""
-                      }`}
-                      key={mode}
-                      onPress={() => setDraftTagMode(mode)}
-                    >
-                      <Text
-                        className={`text-sm ${
-                          isSelected
-                            ? "font-semibold text-foreground"
-                            : "text-muted-foreground"
+            {/* Only once a second tag makes the choice meaningful -- below two
+                tags "all" and "any" select the same entries. Stays full-width
+                here rather than moving onto the section header like web: at
+                393pt it would be squeezed against the collapse chevron, and
+                the helper text stays because this modal covers the results, so
+                toggling gives no visible feedback until Apply dismisses it. */}
+            {draftTags.length >= 2 && (
+              <View className="gap-2 px-4 pb-3">
+                <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+                  {TAG_MODES.map((mode) => {
+                    const isSelected = draftTagMode === mode;
+                    return (
+                      <Pressable
+                        className={`flex-1 items-center rounded-md py-2 ${
+                          isSelected ? "bg-background" : ""
                         }`}
+                        key={mode}
+                        onPress={() => setDraftTagMode(mode)}
                       >
-                        {tagModeLabels[mode]}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
+                        <Text
+                          className={`text-sm ${
+                            isSelected
+                              ? "font-semibold text-foreground"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          {tagModeLabels[mode]}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
 
-              <Text className="text-muted-foreground text-xs">
-                {draftTagMode === "all" ? (
-                  <Trans>Words must have every selected tag.</Trans>
-                ) : (
-                  <Trans>Words need only one of the selected tags.</Trans>
-                )}
-              </Text>
-            </View>
+                <Text className="text-muted-foreground text-xs">
+                  {draftTagMode === "all" ? (
+                    <Trans>Words must have every selected tag.</Trans>
+                  ) : (
+                    <Trans>Words need only one of the selected tags.</Trans>
+                  )}
+                </Text>
+              </View>
+            )}
 
             <View className="px-4 pb-3">
               <TextInput

--- a/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
@@ -12,6 +12,8 @@ import {
   BookType,
   Check,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   FunnelX,
   Lock,
   SlidersHorizontal,
@@ -135,7 +137,186 @@ const CollapsibleSection: FC<{
   );
 };
 
-const TAG_LIST_MAX_HEIGHT = 300;
+/**
+ * Full-screen tag picker, pushed over the filters modal.
+ *
+ * A drill-in rather than a section inside the filters sheet: the tag list is
+ * the only unbounded list in there, and inlining it meant a capped-height
+ * ScrollView nested inside the sheet's own ScrollView. Two vertical scroll
+ * regions in the same direction make the gesture ambiguous, and a ~300pt
+ * window is a poor place to search twenty-plus tags.
+ *
+ * Writes straight into the parent's draft. It deliberately has no Apply of its
+ * own -- nesting a second commit step under the sheet's Apply makes "apply
+ * here, then cancel there" mean something nobody can predict. Closing this is
+ * just "done looking"; the sheet's Apply stays the only commit.
+ */
+const TagPickerModal: FC<{
+  visible: boolean;
+  onClose: () => void;
+  selectedTags: string[];
+  onToggleTag: (tag: string) => void;
+  tagMode: TagMode;
+  onTagModeChange: (mode: TagMode) => void;
+}> = ({
+  visible,
+  onClose,
+  selectedTags,
+  onToggleTag,
+  tagMode,
+  onTagModeChange,
+}) => {
+  const { t } = useLingui();
+  const colors = useThemeColors();
+  const insets = useSafeAreaInsets();
+  const { formatNumber } = useFormatNumber();
+  const tagModeLabels = useTagModeLabels();
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (visible) setSearch("");
+  }, [visible]);
+
+  const { data: availableTags } = useQuery({
+    queryFn: () => dictionaryEntriesTable.tags.query(),
+    ...dictionaryEntriesTable.tags.cacheOptions,
+  });
+
+  const filteredTags = availableTags?.filter(
+    (item) =>
+      !search.trim() || item.tag.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="fullScreen"
+      visible={visible}
+    >
+      <View
+        className="flex-1 bg-background"
+        style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      >
+        <View className="flex-row items-center gap-2 border-border border-b px-4 py-3">
+          <Pressable
+            className="-ml-2 p-2 active:opacity-60"
+            hitSlop={8}
+            onPress={onClose}
+          >
+            <ChevronLeft color={colors.foreground} size={24} />
+          </Pressable>
+          <Text className="flex-1 font-semibold text-foreground text-lg">
+            <Trans>Tags</Trans>
+          </Text>
+          {selectedTags.length > 0 && (
+            <Text className="text-muted-foreground text-sm">
+              {t`${formatNumber(selectedTags.length)} selected`}
+            </Text>
+          )}
+        </View>
+
+        {/* Only once a second tag makes the choice meaningful -- below two tags
+            "all" and "any" select the same entries. The helper text stays
+            because this screen covers the results, so toggling shows nothing
+            until the filters sheet is applied. */}
+        {selectedTags.length >= 2 && (
+          <View className="gap-2 px-4 pt-3">
+            <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
+              {TAG_MODES.map((mode) => {
+                const isSelected = tagMode === mode;
+                return (
+                  <Pressable
+                    className={`flex-1 items-center rounded-md py-2 ${
+                      isSelected ? "bg-background" : ""
+                    }`}
+                    key={mode}
+                    onPress={() => onTagModeChange(mode)}
+                  >
+                    <Text
+                      className={`text-sm ${
+                        isSelected
+                          ? "font-semibold text-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {tagModeLabels[mode]}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <Text className="text-muted-foreground text-xs">
+              {tagMode === "all" ? (
+                <Trans>Words must have every selected tag.</Trans>
+              ) : (
+                <Trans>Words need only one of the selected tags.</Trans>
+              )}
+            </Text>
+          </View>
+        )}
+
+        <View className="px-4 py-3">
+          <TextInput
+            autoCorrect={false}
+            className="rounded-lg bg-muted/40 px-3 py-2.5 text-foreground text-sm"
+            onChangeText={setSearch}
+            placeholder={t`Search tags...`}
+            placeholderTextColor={colors.mutedForeground}
+            value={search}
+          />
+        </View>
+
+        {/* The one scroll region on this screen. */}
+        <ScrollView className="flex-1" keyboardShouldPersistTaps="handled">
+          {filteredTags?.map(({ tag, count }) => {
+            const isSelected = selectedTags.includes(tag);
+            return (
+              <Pressable
+                className="flex-row items-center justify-between px-4 py-3 active:bg-muted/30"
+                key={tag}
+                onPress={() => onToggleTag(tag)}
+              >
+                <View className="flex-1 flex-row items-center gap-3">
+                  <View
+                    className={`h-5.5 w-5.5 items-center justify-center rounded ${
+                      isSelected
+                        ? "bg-primary"
+                        : "border border-border bg-background"
+                    }`}
+                  >
+                    {isSelected && <Check color="#fff" size={14} />}
+                  </View>
+                  <Text
+                    className={`text-base ${
+                      isSelected
+                        ? "font-medium text-foreground"
+                        : "text-foreground"
+                    }`}
+                  >
+                    {tag}
+                  </Text>
+                </View>
+                <Text className="text-muted-foreground text-sm">
+                  {formatNumber(count)}
+                </Text>
+              </Pressable>
+            );
+          })}
+
+          {filteredTags?.length === 0 && (
+            <View className="px-4 py-6">
+              <Text className="text-center text-muted-foreground text-sm">
+                <Trans>No tags found</Trans>
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+};
 
 const FiltersModal: FC<{
   visible: boolean;
@@ -162,10 +343,10 @@ const FiltersModal: FC<{
   const [draftTags, setDraftTags] = useState<string[]>([]);
   const [draftTypes, setDraftTypes] = useState<WordType[]>([]);
   const [draftSort, setDraftSort] = useState<SortOption>("relevance");
-  const [draftTagMode, setDraftTagMode] = useState<TagMode>("all");
-  const [tagSearch, setTagSearch] = useState("");
+  const [draftTagMode, setDraftTagMode] = useState<TagMode>("any");
+  const [tagPickerVisible, setTagPickerVisible] = useState(false);
   const [expandedSection, setExpandedSection] = useState<
-    "tags" | "types" | "sort" | null
+    "types" | "sort" | null
   >("sort");
 
   // Sync draft state from applied state when modal opens
@@ -175,21 +356,10 @@ const FiltersModal: FC<{
       setDraftTypes(appliedTypes);
       setDraftSort(appliedSort);
       setDraftTagMode(appliedTagMode);
-      setTagSearch("");
+      setTagPickerVisible(false);
       setExpandedSection("sort");
     }
   }, [visible]);
-
-  const { data: availableTags } = useQuery({
-    queryFn: () => dictionaryEntriesTable.tags.query(),
-    ...dictionaryEntriesTable.tags.cacheOptions,
-  });
-
-  const filteredTags = availableTags?.filter(
-    (item) =>
-      !tagSearch.trim() ||
-      item.tag.toLowerCase().includes(tagSearch.toLowerCase())
-  );
 
   const toggleTag = (tag: string) => {
     setDraftTags((prev) =>
@@ -207,11 +377,11 @@ const FiltersModal: FC<{
     setAppliedTags([]);
     setAppliedTypes([]);
     setAppliedSort("relevance");
-    setAppliedTagMode("all");
+    setAppliedTagMode("any");
     setDraftTags([]);
     setDraftTypes([]);
     setDraftSort("relevance");
-    setDraftTagMode("all");
+    setDraftTagMode("any");
   };
 
   const handleApply = () => {
@@ -280,118 +450,24 @@ const FiltersModal: FC<{
         </View>
 
         <ScrollView className="flex-1">
-          {/* Tags section */}
-          <CollapsibleSection
-            icon={Tag}
-            isExpanded={expandedSection === "tags"}
-            label={t`Tags`}
-            onToggle={() =>
-              setExpandedSection((prev) => (prev === "tags" ? null : "tags"))
-            }
-            summary={tagsSummary}
+          {/* Tags drill into their own screen rather than expanding inline --
+              see TagPickerModal for why. */}
+          <Pressable
+            className="flex-row items-center gap-2 px-4 py-3 active:bg-muted/30"
+            onPress={() => setTagPickerVisible(true)}
           >
-            {/* Only once a second tag makes the choice meaningful -- below two
-                tags "all" and "any" select the same entries. Stays full-width
-                here rather than moving onto the section header like web: at
-                393pt it would be squeezed against the collapse chevron, and
-                the helper text stays because this modal covers the results, so
-                toggling gives no visible feedback until Apply dismisses it. */}
-            {draftTags.length >= 2 && (
-              <View className="gap-2 px-4 pb-3">
-                <View className="flex-row gap-1 rounded-lg bg-muted/40 p-1">
-                  {TAG_MODES.map((mode) => {
-                    const isSelected = draftTagMode === mode;
-                    return (
-                      <Pressable
-                        className={`flex-1 items-center rounded-md py-2 ${
-                          isSelected ? "bg-background" : ""
-                        }`}
-                        key={mode}
-                        onPress={() => setDraftTagMode(mode)}
-                      >
-                        <Text
-                          className={`text-sm ${
-                            isSelected
-                              ? "font-semibold text-foreground"
-                              : "text-muted-foreground"
-                          }`}
-                        >
-                          {tagModeLabels[mode]}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-
-                <Text className="text-muted-foreground text-xs">
-                  {draftTagMode === "all" ? (
-                    <Trans>Words must have every selected tag.</Trans>
-                  ) : (
-                    <Trans>Words need only one of the selected tags.</Trans>
-                  )}
-                </Text>
-              </View>
+            <Tag color={colors.mutedForeground} size={16} />
+            <Text className="font-semibold text-muted-foreground text-xs uppercase tracking-widest">
+              <Trans>Tags</Trans>
+            </Text>
+            <View className="h-px flex-1 bg-border/50" />
+            {tagsSummary && (
+              <Text className="text-muted-foreground text-sm">
+                {tagsSummary}
+              </Text>
             )}
-
-            <View className="px-4 pb-3">
-              <TextInput
-                className="rounded-lg bg-muted/40 px-3 py-2.5 text-foreground text-sm"
-                onChangeText={setTagSearch}
-                placeholder={t`Search tags...`}
-                placeholderTextColor={colors.mutedForeground}
-                value={tagSearch}
-              />
-            </View>
-
-            <ScrollView
-              nestedScrollEnabled
-              showsVerticalScrollIndicator
-              style={{ maxHeight: TAG_LIST_MAX_HEIGHT }}
-            >
-              {filteredTags?.map(({ tag, count }) => {
-                const isSelected = draftTags.includes(tag);
-                return (
-                  <Pressable
-                    className="flex-row items-center justify-between px-4 py-3 active:bg-muted/30"
-                    key={tag}
-                    onPress={() => toggleTag(tag)}
-                  >
-                    <View className="flex-row items-center gap-3">
-                      <View
-                        className={`h-5.5 w-5.5 items-center justify-center rounded ${
-                          isSelected
-                            ? "bg-primary"
-                            : "border border-border bg-background"
-                        }`}
-                      >
-                        {isSelected && <Check color="#fff" size={14} />}
-                      </View>
-                      <Text
-                        className={`text-base ${
-                          isSelected
-                            ? "font-medium text-foreground"
-                            : "text-foreground"
-                        }`}
-                      >
-                        {tag}
-                      </Text>
-                    </View>
-                    <Text className="text-muted-foreground text-sm">
-                      {formatNumber(count)}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-
-              {filteredTags?.length === 0 && (
-                <View className="px-4 py-6">
-                  <Text className="text-center text-muted-foreground text-sm">
-                    <Trans>No tags found</Trans>
-                  </Text>
-                </View>
-              )}
-            </ScrollView>
-          </CollapsibleSection>
+            <ChevronRight color={colors.mutedForeground} size={16} />
+          </Pressable>
 
           {/* Word Types section */}
           <CollapsibleSection
@@ -496,6 +572,15 @@ const FiltersModal: FC<{
           </View>
         </View>
       </View>
+
+      <TagPickerModal
+        onClose={() => setTagPickerVisible(false)}
+        onTagModeChange={setDraftTagMode}
+        onToggleTag={toggleTag}
+        selectedTags={draftTags}
+        tagMode={draftTagMode}
+        visible={tagPickerVisible}
+      />
     </Modal>
   );
 };

--- a/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryFilters.tsx
@@ -222,11 +222,12 @@ const FiltersModal: FC<{
     onClose();
   };
 
+  // Matches activeFilterCountAtom: tagMode on its own isn't an active filter,
+  // so it shouldn't be what makes "Clear all" appear.
   const hasAppliedFilters =
     appliedTags.length > 0 ||
     appliedTypes.length > 0 ||
-    appliedSort !== "relevance" ||
-    appliedTagMode !== "all";
+    appliedSort !== "relevance";
 
   const hasDraftChanges =
     JSON.stringify(draftTags) !== JSON.stringify(appliedTags) ||

--- a/apps/mobile/src/components/dictionary/DictionaryList.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryList.tsx
@@ -4,6 +4,7 @@
 
 import type {
   SelectDictionaryEntry,
+  TagMode,
   WordType,
 } from "@bahar/drizzle-user-db-schemas";
 import { Trans } from "@lingui/react/macro";
@@ -43,6 +44,7 @@ import { DictionaryEntryCard } from "./DictionaryEntryCard";
 interface DictionaryListProps {
   searchQuery: string;
   tags?: string[];
+  tagMode?: TagMode;
   types?: WordType[];
   sort?: SortOption;
   bottomInset?: number;
@@ -100,6 +102,7 @@ const LoadingIndicator: FC = () => (
 export const DictionaryList: FC<DictionaryListProps> = ({
   searchQuery,
   tags,
+  tagMode,
   types,
   sort,
   bottomInset = 0,
@@ -111,6 +114,7 @@ export const DictionaryList: FC<DictionaryListProps> = ({
     tags?.length || types?.length
       ? {
           tags: tags?.length ? tags : undefined,
+          tagMode,
           types: types?.length ? types : undefined,
         }
       : undefined;

--- a/apps/mobile/src/components/dictionary/DictionaryList.tsx
+++ b/apps/mobile/src/components/dictionary/DictionaryList.tsx
@@ -73,7 +73,7 @@ const EmptyDictionary: FC = () => {
   );
 };
 
-const NoResults: FC = () => {
+const NoResults: FC<{ hasSearchQuery: boolean }> = ({ hasSearchQuery }) => {
   const colors = useThemeColors();
   return (
     <Animated.View
@@ -87,7 +87,11 @@ const NoResults: FC = () => {
         <Trans>No results found</Trans>
       </Text>
       <Text className="px-8 text-center text-muted-foreground">
-        <Trans>Try a different search term</Trans>
+        {hasSearchQuery ? (
+          <Trans>Try a different search term</Trans>
+        ) : (
+          <Trans>Try adjusting your filters</Trans>
+        )}
       </Text>
     </Animated.View>
   );
@@ -272,7 +276,13 @@ export const DictionaryList: FC<DictionaryListProps> = ({
 
   const emptyComponent = (() => {
     if (isLoading) return <LoadingIndicator />;
-    if (searchQuery.trim()) return <NoResults />;
+    // Filters count the same as a search term: narrowing to zero with no
+    // search term would otherwise claim the dictionary itself is empty.
+    const hasSearchQuery = searchQuery.trim().length > 0;
+    const hasActiveFilters = !!(tags?.length || types?.length);
+    if (hasSearchQuery || hasActiveFilters) {
+      return <NoResults hasSearchQuery={hasSearchQuery} />;
+    }
     return <EmptyDictionary />;
   })();
   return (

--- a/apps/mobile/src/components/ui/button.tsx
+++ b/apps/mobile/src/components/ui/button.tsx
@@ -107,7 +107,7 @@ export const Button: FC<ButtonProps> = ({
             className={cn(textVariants({ variant, className }), "text-center")}
           >
             {typeof children === "function"
-              ? children({ pressed: false })
+              ? children({ pressed: false, hovered: false })
               : children}
           </Text>
         )}

--- a/apps/mobile/src/hooks/useSearch.ts
+++ b/apps/mobile/src/hooks/useSearch.ts
@@ -154,9 +154,9 @@ export const useInfiniteSearch = (
     if (!tags?.length && !types?.length) return undefined;
 
     const tagFilter =
-      params.filters?.tagMode === "any"
-        ? { containsAny: tags }
-        : { containsAll: tags };
+      params.filters?.tagMode === "all"
+        ? { containsAll: tags }
+        : { containsAny: tags };
 
     return {
       ...(tags?.length ? { tags: tagFilter } : {}),

--- a/apps/mobile/src/hooks/useSearch.ts
+++ b/apps/mobile/src/hooks/useSearch.ts
@@ -5,7 +5,7 @@
  * Jotai atoms for shared state so search can be reset from other screens.
  */
 
-import type { WordType } from "@bahar/drizzle-user-db-schemas";
+import type { TagMode, WordType } from "@bahar/drizzle-user-db-schemas";
 import { detectLanguage } from "@bahar/search/arabic";
 import {
   type SearchDictionaryOptions,
@@ -111,6 +111,7 @@ interface UseInfiniteSearchParams {
   term?: string;
   filters?: {
     tags?: string[];
+    tagMode?: TagMode;
     types?: WordType[];
   };
   sort?: SortOption;
@@ -151,8 +152,14 @@ export const useInfiniteSearch = (
     const tags = params.filters?.tags;
     const types = params.filters?.types;
     if (!tags?.length && !types?.length) return undefined;
+
+    const tagFilter =
+      params.filters?.tagMode === "any"
+        ? { containsAny: tags }
+        : { containsAll: tags };
+
     return {
-      ...(tags?.length ? { tags: { containsAll: tags } } : {}),
+      ...(tags?.length ? { tags: tagFilter } : {}),
       ...(types?.length ? { type: { in: types } } : {}),
     };
   }, [paramsKey]);

--- a/apps/mobile/src/lib/store/filters.ts
+++ b/apps/mobile/src/lib/store/filters.ts
@@ -29,7 +29,7 @@ const sortOptionStorageAtom = atomWithStorage(
 
 const tagModeStorageAtom = atomWithStorage<TagMode>(
   `${FILTERS_STORAGE_KEY_PREFIX}:tagMode`,
-  "all",
+  "any",
   createJSONStorage<TagMode>(() => AsyncStorage),
   { getOnInit: true }
 );
@@ -73,7 +73,7 @@ export const sortOptionAtom = atom(
 export const tagModeAtom = atom(
   (get) => {
     const val = get(tagModeStorageAtom);
-    return val === "any" ? "any" : ("all" as TagMode);
+    return val === "all" ? "all" : ("any" as TagMode);
   },
   (_get, set, update: TagMode) => {
     set(tagModeStorageAtom, update);

--- a/apps/mobile/src/lib/store/filters.ts
+++ b/apps/mobile/src/lib/store/filters.ts
@@ -80,17 +80,16 @@ export const tagModeAtom = atom(
   }
 );
 
+// tagMode is deliberately not counted: it modifies how the selected tags
+// combine rather than narrowing anything on its own, so counting it would
+// claim a filter is active when nothing has been filtered.
 export const activeFilterCountAtom = atom((get) => {
   const tags = get(selectedTagsAtom);
   const types = get(selectedTypesAtom);
   const sort = get(sortOptionAtom);
-  const tagMode = get(tagModeAtom);
   let count = 0;
   if (tags.length > 0) count++;
   if (types.length > 0) count++;
   if (sort !== "relevance") count++;
-  // Filters persist across launches here, so a non-default mode has to show up
-  // in the badge -- otherwise it silently narrows results weeks later.
-  if (tagMode !== "all") count++;
   return count;
 });

--- a/apps/mobile/src/lib/store/filters.ts
+++ b/apps/mobile/src/lib/store/filters.ts
@@ -1,4 +1,4 @@
-import type { WordType } from "@bahar/drizzle-user-db-schemas";
+import type { TagMode, WordType } from "@bahar/drizzle-user-db-schemas";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { atom } from "jotai";
 import { atomWithStorage, createJSONStorage } from "jotai/utils";
@@ -24,6 +24,13 @@ const sortOptionStorageAtom = atomWithStorage(
   `${FILTERS_STORAGE_KEY_PREFIX}:sortOption`,
   "relevance",
   createJSONStorage<SortOption>(() => AsyncStorage),
+  { getOnInit: true }
+);
+
+const tagModeStorageAtom = atomWithStorage<TagMode>(
+  `${FILTERS_STORAGE_KEY_PREFIX}:tagMode`,
+  "all",
+  createJSONStorage<TagMode>(() => AsyncStorage),
   { getOnInit: true }
 );
 
@@ -63,13 +70,27 @@ export const sortOptionAtom = atom(
   }
 );
 
+export const tagModeAtom = atom(
+  (get) => {
+    const val = get(tagModeStorageAtom);
+    return val === "any" ? "any" : ("all" as TagMode);
+  },
+  (_get, set, update: TagMode) => {
+    set(tagModeStorageAtom, update);
+  }
+);
+
 export const activeFilterCountAtom = atom((get) => {
   const tags = get(selectedTagsAtom);
   const types = get(selectedTypesAtom);
   const sort = get(sortOptionAtom);
+  const tagMode = get(tagModeAtom);
   let count = 0;
   if (tags.length > 0) count++;
   if (types.length > 0) count++;
   if (sort !== "relevance") count++;
+  // Filters persist across launches here, so a non-default mode has to show up
+  // in the badge -- otherwise it silently narrows results weeks later.
+  if (tagMode !== "all") count++;
   return count;
 });

--- a/apps/web/src/components/Autocomplete.tsx
+++ b/apps/web/src/components/Autocomplete.tsx
@@ -101,7 +101,10 @@ export const Autocomplete: FC<AutocompleteProps> = ({
           !addedTagIsFiltered &&
           (tags.length > 0 || (tags.length === 0 && allowAdd)) && (
             <div
-              className="absolute top-12 right-0 left-0 max-h-[164px] overflow-y-auto rounded-lg border-2 border-border bg-background"
+              // z-index so the dropdown paints over whatever follows it in the
+              // DOM. Without it the dialog footer's button, being a later
+              // sibling, covers the bottom of the list.
+              className="absolute top-12 right-0 left-0 z-20 max-h-[164px] overflow-y-auto rounded-lg border-2 border-border bg-background"
               ref={dropdownRef}
             >
               {(() => {

--- a/apps/web/src/components/features/decks/DeckDialogContent.tsx
+++ b/apps/web/src/components/features/decks/DeckDialogContent.tsx
@@ -243,29 +243,35 @@ export const DeckDialogContent = ({
                 <Trans>Tags</Trans>
               </Label>
 
-              {/* Mode and its explanation sit above the picker so the picker
-                  stays adjacent to the tag pills it produces. */}
+              {/* Mode sits above the picker so the picker stays adjacent to
+                  the tag pills it produces, and only appears once a second tag
+                  makes the choice meaningful. The description below stays put
+                  either way -- this form has always had one, and unlike the
+                  home filters it shows no result count, so nothing else here
+                  tells you what the current mode does. */}
               <div className="col-span-3 flex flex-col gap-y-2">
-                <div className="flex flex-wrap gap-2">
-                  {TAG_MODES.map((mode) => {
-                    const isSelected = selectedTagMode === mode;
-                    return (
-                      <button
-                        className={cn(
-                          "rounded-full border px-3.5 py-1.5 text-sm transition-colors",
-                          isSelected
-                            ? "border-primary bg-primary/10 font-medium text-primary"
-                            : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
-                        )}
-                        key={mode}
-                        onClick={() => form.setValue("tagMode", mode)}
-                        type="button"
-                      >
-                        {tagModeLabels[mode]}
-                      </button>
-                    );
-                  })}
-                </div>
+                {tagFields.length >= 2 && (
+                  <div className="flex items-center gap-0.5 self-start rounded-full bg-muted p-0.5">
+                    {TAG_MODES.map((mode) => {
+                      const isSelected = selectedTagMode === mode;
+                      return (
+                        <button
+                          className={cn(
+                            "rounded-full px-2.5 py-1 text-xs transition-colors",
+                            isSelected
+                              ? "bg-background font-medium text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          )}
+                          key={mode}
+                          onClick={() => form.setValue("tagMode", mode)}
+                          type="button"
+                        >
+                          {tagModeLabels[mode]}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
 
                 <p className="text-muted-foreground text-xs">
                   {selectedTagMode === "all" ? (

--- a/apps/web/src/components/features/decks/DeckDialogContent.tsx
+++ b/apps/web/src/components/features/decks/DeckDialogContent.tsx
@@ -166,7 +166,14 @@ export const DeckDialogContent = ({
 
   const onSubmit = async (values: z.infer<typeof DeckFormSchema>) => {
     const { name, tags, tagMode, types } = values;
-    const filters = { tags: tags?.map((tag) => tag.word), tagMode, types };
+    const tagWords = tags?.map((tag) => tag.word);
+    // Matches the mobile deck forms: tagMode only means something alongside
+    // tags, so a deck with none doesn't carry one.
+    const filters = {
+      tags: tagWords,
+      ...(tagWords?.length ? { tagMode } : {}),
+      types,
+    };
 
     try {
       if (isEditing) {

--- a/apps/web/src/components/features/decks/DeckDialogContent.tsx
+++ b/apps/web/src/components/features/decks/DeckDialogContent.tsx
@@ -139,10 +139,10 @@ export const DeckDialogContent = ({
     values: {
       name: deck?.name ?? "",
       tags: deck?.filters?.tags?.map((tag) => ({ word: tag })) ?? [],
-      // Decks saved before tagMode existed were matched with "any", so an
-      // existing deck opens on what it has actually been doing. New decks
-      // start on "all", which is what people expect a multi-tag deck to mean.
-      tagMode: deck ? (deck.filters?.tagMode ?? "any") : "all",
+      // "any" is the default everywhere, and it's also what decks saved before
+      // tagMode existed have always done, so an existing deck opens on what it
+      // has actually been doing.
+      tagMode: deck?.filters?.tagMode ?? "any",
       types: deck?.filters?.types ?? allTypes,
     },
   });
@@ -243,12 +243,11 @@ export const DeckDialogContent = ({
                 <Trans>Tags</Trans>
               </Label>
 
-              {/* Mode sits above the picker so the picker stays adjacent to
-                  the tag pills it produces, and only appears once a second tag
-                  makes the choice meaningful. The description below stays put
-                  either way -- this form has always had one, and unlike the
-                  home filters it shows no result count, so nothing else here
-                  tells you what the current mode does. */}
+              {/* Mode sits above the picker, and only appears once a second tag
+                  makes the choice meaningful. The description stays put either
+                  way -- this form has always had one, and unlike the home
+                  filters it shows no result count, so nothing else here tells
+                  you what the current mode does. */}
               <div className="col-span-3 flex flex-col gap-y-2">
                 {tagFields.length >= 2 && (
                   <div className="flex items-center gap-0.5 self-start rounded-full bg-muted p-0.5">
@@ -273,6 +272,14 @@ export const DeckDialogContent = ({
                   </div>
                 )}
 
+                <Autocomplete
+                  allowAdd={false}
+                  filter={tagFields.map((field) => field.word)}
+                  onClick={(val) => {
+                    appendTag({ word: val });
+                  }}
+                />
+
                 <p className="text-muted-foreground text-xs">
                   {selectedTagMode === "all" ? (
                     <Trans>
@@ -286,14 +293,6 @@ export const DeckDialogContent = ({
                     </Trans>
                   )}
                 </p>
-
-                <Autocomplete
-                  allowAdd={false}
-                  filter={tagFields.map((field) => field.word)}
-                  onClick={(val) => {
-                    appendTag({ word: val });
-                  }}
-                />
               </div>
             </div>
           </div>

--- a/apps/web/src/components/features/decks/DeckDialogContent.tsx
+++ b/apps/web/src/components/features/decks/DeckDialogContent.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@bahar/design-system";
+import { TAG_MODES, type TagMode } from "@bahar/drizzle-user-db-schemas";
 import { Badge } from "@bahar/web-ui/components/badge";
 import { Button } from "@bahar/web-ui/components/button";
 import { Checkbox } from "@bahar/web-ui/components/checkbox";
@@ -37,6 +39,7 @@ const DeckSchema = z.object({
   filters: z
     .object({
       tags: z.array(z.string()).optional(),
+      tagMode: z.enum(TAG_MODES).optional(),
       state: z
         .array(
           z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)])
@@ -52,6 +55,7 @@ const DeckSchema = z.object({
 const DeckFormSchema = z.object({
   name: z.string().min(1),
   tags: z.array(z.object({ word: z.string() })).optional(),
+  tagMode: z.enum(TAG_MODES),
   types: z.array(z.enum(["ism", "fi'l", "harf", "expression"])).optional(),
 });
 
@@ -135,6 +139,10 @@ export const DeckDialogContent = ({
     values: {
       name: deck?.name ?? "",
       tags: deck?.filters?.tags?.map((tag) => ({ word: tag })) ?? [],
+      // Decks saved before tagMode existed were matched with "any", so an
+      // existing deck opens on what it has actually been doing. New decks
+      // start on "all", which is what people expect a multi-tag deck to mean.
+      tagMode: deck ? (deck.filters?.tagMode ?? "any") : "all",
       types: deck?.filters?.types ?? allTypes,
     },
   });
@@ -148,11 +156,17 @@ export const DeckDialogContent = ({
     control: form.control,
   });
 
+  const selectedTagMode = form.watch("tagMode");
+  const tagModeLabels: Record<TagMode, string> = {
+    all: t`Match all`,
+    any: t`Match any`,
+  };
+
   const isEditing = !!deck;
 
   const onSubmit = async (values: z.infer<typeof DeckFormSchema>) => {
-    const { name, tags, types } = values;
-    const filters = { tags: tags?.map((tag) => tag.word), types };
+    const { name, tags, tagMode, types } = values;
+    const filters = { tags: tags?.map((tag) => tag.word), tagMode, types };
 
     try {
       if (isEditing) {
@@ -224,26 +238,58 @@ export const DeckDialogContent = ({
           </div>
 
           <div className="mb-2 flex flex-col gap-y-4">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label className="font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ltr:text-sm rtl:text-base">
+            <div className="grid grid-cols-4 items-start gap-4">
+              <Label className="pt-1.5 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ltr:text-sm rtl:text-base">
                 <Trans>Tags</Trans>
               </Label>
 
-              <Autocomplete
-                allowAdd={false}
-                className="col-span-3"
-                filter={tagFields.map((field) => field.word)}
-                onClick={(val) => {
-                  appendTag({ word: val });
-                }}
-              />
-            </div>
+              {/* Mode and its explanation sit above the picker so the picker
+                  stays adjacent to the tag pills it produces. */}
+              <div className="col-span-3 flex flex-col gap-y-2">
+                <div className="flex flex-wrap gap-2">
+                  {TAG_MODES.map((mode) => {
+                    const isSelected = selectedTagMode === mode;
+                    return (
+                      <button
+                        className={cn(
+                          "rounded-full border px-3.5 py-1.5 text-sm transition-colors",
+                          isSelected
+                            ? "border-primary bg-primary/10 font-medium text-primary"
+                            : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                        )}
+                        key={mode}
+                        onClick={() => form.setValue("tagMode", mode)}
+                        type="button"
+                      >
+                        {tagModeLabels[mode]}
+                      </button>
+                    );
+                  })}
+                </div>
 
-            <p className="text-muted-foreground ltr:text-sm rtl:text-base">
-              <Trans>
-                Words that have any of these tags will be included in the deck.
-              </Trans>
-            </p>
+                <p className="text-muted-foreground text-xs">
+                  {selectedTagMode === "all" ? (
+                    <Trans>
+                      Only words that have every one of these tags will be
+                      included in the deck.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      Words that have any of these tags will be included in the
+                      deck.
+                    </Trans>
+                  )}
+                </p>
+
+                <Autocomplete
+                  allowAdd={false}
+                  filter={tagFields.map((field) => field.word)}
+                  onClick={(val) => {
+                    appendTag({ word: val });
+                  }}
+                />
+              </div>
+            </div>
           </div>
 
           <ul className="mb-3 flex flex-wrap gap-2">

--- a/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
+++ b/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
@@ -104,19 +104,20 @@ export const DictionaryFilters = () => {
     !!(
       filteredTags?.length ||
       filteredTypes?.length ||
-      activeTagMode !== "all" ||
       (sort && sort !== "relevance")
     )
   );
 
+  // tagMode is deliberately absent here: it modifies how the selected tags
+  // combine rather than narrowing anything on its own, so counting it would
+  // claim a filter is active when nothing has been filtered.
   const activeFilterCount = useMemo(() => {
     let count = 0;
     if (filteredTags?.length) count += filteredTags.length;
     if (filteredTypes?.length) count += filteredTypes.length;
-    if (activeTagMode !== "all") count += 1;
     if (sort && sort !== "relevance") count += 1;
     return count;
-  }, [filteredTags, filteredTypes, activeTagMode, sort]);
+  }, [filteredTags, filteredTypes, sort]);
 
   const hasActiveFilters = activeFilterCount > 0;
 

--- a/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
+++ b/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
@@ -99,6 +99,7 @@ export const DictionaryFilters = () => {
     from: "/_authorized-layout/_search-layout",
   });
   const activeTagMode: TagMode = tagMode ?? "all";
+  const isTagModeRelevant = (filteredTags?.length ?? 0) >= 2;
   const [isExpanded, setIsExpanded] = useSessionStorage(
     "isFiltersExpanded",
     !!(
@@ -170,49 +171,47 @@ export const DictionaryFilters = () => {
             </section>
 
             <section className="flex flex-col gap-y-2">
-              <p className="font-medium text-muted-foreground text-sm">
-                <Trans>Tags</Trans>
-              </p>
+              {/* On the label row, and only once a second tag makes the choice
+                  meaningful -- below two tags "all" and "any" select the same
+                  entries, so the control would be inert. Deliberately quieter
+                  than the word-type pills: this modifies the filter below it
+                  rather than being a filter value of its own. */}
+              <div className="flex items-center justify-between gap-4">
+                <p className="font-medium text-muted-foreground text-sm">
+                  <Trans>Tags</Trans>
+                </p>
 
-              {/* Above the tag picker, not below it: the picker and the pills
-                  it produces have to stay adjacent, and putting the mode
-                  between them makes it ambiguous which one it applies to. */}
-              <div className="flex flex-wrap gap-2">
-                {TAG_MODES.map((mode) => {
-                  const isSelected = activeTagMode === mode;
-                  return (
-                    <button
-                      className={cn(
-                        "rounded-full border px-3.5 py-1.5 text-sm transition-colors",
-                        isSelected
-                          ? "border-primary bg-primary/10 font-medium text-primary"
-                          : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
-                      )}
-                      key={mode}
-                      onClick={() => {
-                        navigate({
-                          to: "/",
-                          search: (prev) => ({
-                            ...prev,
-                            tagMode: mode === "all" ? undefined : mode,
-                          }),
-                        });
-                      }}
-                      type="button"
-                    >
-                      {tagModeLabels[mode]}
-                    </button>
-                  );
-                })}
-              </div>
-
-              <p className="text-muted-foreground text-xs">
-                {activeTagMode === "all" ? (
-                  <Trans>Words must have every selected tag.</Trans>
-                ) : (
-                  <Trans>Words need only one of the selected tags.</Trans>
+                {isTagModeRelevant && (
+                  <div className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
+                    {TAG_MODES.map((mode) => {
+                      const isSelected = activeTagMode === mode;
+                      return (
+                        <button
+                          className={cn(
+                            "rounded-full px-2.5 py-1 text-xs transition-colors",
+                            isSelected
+                              ? "bg-background font-medium text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          )}
+                          key={mode}
+                          onClick={() => {
+                            navigate({
+                              to: "/",
+                              search: (prev) => ({
+                                ...prev,
+                                tagMode: mode === "all" ? undefined : mode,
+                              }),
+                            });
+                          }}
+                          type="button"
+                        >
+                          {tagModeLabels[mode]}
+                        </button>
+                      );
+                    })}
+                  </div>
                 )}
-              </p>
+              </div>
 
               <TagsFilter />
 

--- a/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
+++ b/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
@@ -98,7 +98,7 @@ export const DictionaryFilters = () => {
   } = useSearch({
     from: "/_authorized-layout/_search-layout",
   });
-  const activeTagMode: TagMode = tagMode ?? "all";
+  const activeTagMode: TagMode = tagMode ?? "any";
   const isTagModeRelevant = (filteredTags?.length ?? 0) >= 2;
   const [isExpanded, setIsExpanded] = useSessionStorage(
     "isFiltersExpanded",
@@ -199,7 +199,7 @@ export const DictionaryFilters = () => {
                               to: "/",
                               search: (prev) => ({
                                 ...prev,
-                                tagMode: mode === "all" ? undefined : mode,
+                                tagMode: mode === "any" ? undefined : mode,
                               }),
                             });
                           }}

--- a/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
+++ b/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
@@ -1,5 +1,10 @@
 import { cn } from "@bahar/design-system";
-import { WORD_TYPES, type WordType } from "@bahar/drizzle-user-db-schemas";
+import {
+  TAG_MODES,
+  type TagMode,
+  WORD_TYPES,
+  type WordType,
+} from "@bahar/drizzle-user-db-schemas";
 import { Button } from "@bahar/web-ui/components/button";
 import {
   Select,
@@ -70,24 +75,36 @@ const useWordTypeLabels = (): Record<WordType, string> => {
   };
 };
 
+const useTagModeLabels = (): Record<TagMode, string> => {
+  const { t } = useLingui();
+  return {
+    all: t`Match all`,
+    any: t`Match any`,
+  };
+};
+
 export const DictionaryFilters = () => {
   const navigate = useNavigate();
   const dir = useDir();
   const { formatNumber } = useFormatNumber();
   const { isFreeUser } = useUserPlan();
   const wordTypeLabels = useWordTypeLabels();
+  const tagModeLabels = useTagModeLabels();
   const {
     tags: filteredTags,
+    tagMode,
     types: filteredTypes,
     sort,
   } = useSearch({
     from: "/_authorized-layout/_search-layout",
   });
+  const activeTagMode: TagMode = tagMode ?? "all";
   const [isExpanded, setIsExpanded] = useSessionStorage(
     "isFiltersExpanded",
     !!(
       filteredTags?.length ||
       filteredTypes?.length ||
+      activeTagMode !== "all" ||
       (sort && sort !== "relevance")
     )
   );
@@ -96,9 +113,10 @@ export const DictionaryFilters = () => {
     let count = 0;
     if (filteredTags?.length) count += filteredTags.length;
     if (filteredTypes?.length) count += filteredTypes.length;
+    if (activeTagMode !== "all") count += 1;
     if (sort && sort !== "relevance") count += 1;
     return count;
-  }, [filteredTags, filteredTypes, sort]);
+  }, [filteredTags, filteredTypes, activeTagMode, sort]);
 
   const hasActiveFilters = activeFilterCount > 0;
 
@@ -153,6 +171,46 @@ export const DictionaryFilters = () => {
             <section className="flex flex-col gap-y-2">
               <p className="font-medium text-muted-foreground text-sm">
                 <Trans>Tags</Trans>
+              </p>
+
+              {/* Above the tag picker, not below it: the picker and the pills
+                  it produces have to stay adjacent, and putting the mode
+                  between them makes it ambiguous which one it applies to. */}
+              <div className="flex flex-wrap gap-2">
+                {TAG_MODES.map((mode) => {
+                  const isSelected = activeTagMode === mode;
+                  return (
+                    <button
+                      className={cn(
+                        "rounded-full border px-3.5 py-1.5 text-sm transition-colors",
+                        isSelected
+                          ? "border-primary bg-primary/10 font-medium text-primary"
+                          : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                      )}
+                      key={mode}
+                      onClick={() => {
+                        navigate({
+                          to: "/",
+                          search: (prev) => ({
+                            ...prev,
+                            tagMode: mode === "all" ? undefined : mode,
+                          }),
+                        });
+                      }}
+                      type="button"
+                    >
+                      {tagModeLabels[mode]}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <p className="text-muted-foreground text-xs">
+                {activeTagMode === "all" ? (
+                  <Trans>Words must have every selected tag.</Trans>
+                ) : (
+                  <Trans>Words need only one of the selected tags.</Trans>
+                )}
               </p>
 
               <TagsFilter />

--- a/apps/web/src/components/search/InfiniteScroll.tsx
+++ b/apps/web/src/components/search/InfiniteScroll.tsx
@@ -773,7 +773,7 @@ const PIXEL_HEIGHT_OFFSET = 800;
 export const InfiniteScroll: FC<{ searchQuery?: string }> = ({
   searchQuery,
 }) => {
-  const { tags, types, sort } = useSearch({
+  const { tags, tagMode, types, sort } = useSearch({
     from: "/_authorized-layout/_search-layout",
   });
   const { isFreeUser } = useUserPlan();
@@ -784,7 +784,7 @@ export const InfiniteScroll: FC<{ searchQuery?: string }> = ({
     hasMore,
   } = useInfiniteScroll({
     term: searchQuery,
-    filters: { tags, types },
+    filters: { tags, tagMode, types },
     sort: sort === "difficulty" && isFreeUser ? undefined : sort,
   });
   const [ref, { height }] = useMeasure();

--- a/apps/web/src/components/search/InfiniteScroll.tsx
+++ b/apps/web/src/components/search/InfiniteScroll.tsx
@@ -821,11 +821,19 @@ export const InfiniteScroll: FC<{ searchQuery?: string }> = ({
   }, [shouldLoadMore]);
 
   const hasSearchQuery = searchQuery && searchQuery.trim().length > 0;
-  const showEmptyDictionary = !(hits?.length || hasSearchQuery);
+  // Filters count the same as a search term here: without this, narrowing to
+  // zero with no search term falls through to the empty-dictionary state and
+  // tells someone with thousands of entries that they have none.
+  const hasActiveFilters = !!(tags?.length || types?.length);
+  const showEmptyDictionary = !(
+    hits?.length ||
+    hasSearchQuery ||
+    hasActiveFilters
+  );
   const debouncedShowEmptyDictionary = useDebounce(showEmptyDictionary, 150);
 
   if (!hits?.length) {
-    if (hasSearchQuery) {
+    if (hasSearchQuery || hasActiveFilters) {
       return (
         <motion.div
           animate={{ opacity: 1, y: 0 }}
@@ -839,7 +847,11 @@ export const InfiniteScroll: FC<{ searchQuery?: string }> = ({
             <Trans>No results found</Trans>
           </p>
           <p className="text-muted-foreground">
-            <Trans>Try a different search term</Trans>
+            {hasSearchQuery ? (
+              <Trans>Try a different search term</Trans>
+            ) : (
+              <Trans>Try adjusting your filters</Trans>
+            )}
           </p>
         </motion.div>
       );

--- a/apps/web/src/hooks/search/useSearch.ts
+++ b/apps/web/src/hooks/search/useSearch.ts
@@ -1,4 +1,4 @@
-import type { WordType } from "@bahar/drizzle-user-db-schemas";
+import type { TagMode, WordType } from "@bahar/drizzle-user-db-schemas";
 import {
   type SearchDictionaryOptions,
   type SearchLanguage,
@@ -135,6 +135,7 @@ export const useInfiniteScroll = (
     term?: string;
     filters?: {
       tags?: string[];
+      tagMode?: TagMode;
       types?: WordType[];
     };
     sort?: SortOption;
@@ -157,8 +158,14 @@ export const useInfiniteScroll = (
     const tags = params.filters?.tags;
     const types = params.filters?.types;
     if (!tags?.length && !types?.length) return undefined;
+
+    const tagFilter =
+      params.filters?.tagMode === "any"
+        ? { containsAny: tags }
+        : { containsAll: tags };
+
     return {
-      ...(tags?.length ? { tags: { containsAll: tags } } : {}),
+      ...(tags?.length ? { tags: tagFilter } : {}),
       ...(types?.length ? { type: { in: types } } : {}),
     };
   }, [paramsKey]);

--- a/apps/web/src/hooks/search/useSearch.ts
+++ b/apps/web/src/hooks/search/useSearch.ts
@@ -160,9 +160,9 @@ export const useInfiniteScroll = (
     if (!tags?.length && !types?.length) return undefined;
 
     const tagFilter =
-      params.filters?.tagMode === "any"
-        ? { containsAny: tags }
-        : { containsAll: tags };
+      params.filters?.tagMode === "all"
+        ? { containsAll: tags }
+        : { containsAny: tags };
 
     return {
       ...(tags?.length ? { tags: tagFilter } : {}),

--- a/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
@@ -1,4 +1,4 @@
-import { WORD_TYPES } from "@bahar/drizzle-user-db-schemas";
+import { TAG_MODES, WORD_TYPES } from "@bahar/drizzle-user-db-schemas";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
@@ -12,6 +12,9 @@ import { queryClient } from "@/lib/query";
 
 const filtersSchema = z.object({
   tags: z.array(z.string()).optional(),
+  // Absent means "all", so a shared or bookmarked URL without it filters the
+  // way the dictionary search always has.
+  tagMode: z.enum(TAG_MODES).optional(),
   types: z.array(z.enum(WORD_TYPES)).optional(),
   sort: z.enum(SORT_OPTIONS).optional(),
 });

--- a/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
+++ b/apps/web/src/routes/_authorized-layout/_search-layout/route.tsx
@@ -12,8 +12,8 @@ import { queryClient } from "@/lib/query";
 
 const filtersSchema = z.object({
   tags: z.array(z.string()).optional(),
-  // Absent means "all", so a shared or bookmarked URL without it filters the
-  // way the dictionary search always has.
+  // Absent means "any", matching DEFAULT_TAG_MODE, so only the non-default
+  // shows up in the URL.
   tagMode: z.enum(TAG_MODES).optional(),
   types: z.array(z.enum(WORD_TYPES)).optional(),
   sort: z.enum(SORT_OPTIONS).optional(),

--- a/packages/db-operations/src/constants.ts
+++ b/packages/db-operations/src/constants.ts
@@ -61,13 +61,12 @@ export const MAX_POSTPONE_WINDOW_DAYS = 30;
 export const BATCH_SIZE = 500;
 
 /**
- * Tag combination used by deck and flashcard queries when a deck's filters
- * don't specify one.
+ * Tag combination used when filters don't specify one.
  *
- * `"any"` because that is what these queries have always done -- the tag
- * subquery matches an entry carrying any one of the deck's tags. Defaulting to
- * `"all"` here would silently shrink every existing multi-tag deck, so decks
- * saved before `tagMode` existed keep their current contents and only an
- * explicit user choice changes them.
+ * `"any"` because that is what the deck and flashcard tag subquery has always
+ * done -- it matches an entry carrying any one of the tags. Defaulting to
+ * `"all"` would silently shrink every existing multi-tag deck, so decks saved
+ * before `tagMode` existed keep their current contents and only an explicit
+ * user choice changes them.
  */
-export const DEFAULT_DECK_TAG_MODE: TagMode = "any";
+export const DEFAULT_TAG_MODE: TagMode = "any";

--- a/packages/db-operations/src/constants.ts
+++ b/packages/db-operations/src/constants.ts
@@ -2,7 +2,10 @@
  * Shared constants for database operations.
  */
 
-import type { SelectDictionaryEntry } from "@bahar/drizzle-user-db-schemas";
+import type {
+  SelectDictionaryEntry,
+  TagMode,
+} from "@bahar/drizzle-user-db-schemas";
 
 /**
  * All columns in the dictionary_entries table.
@@ -56,3 +59,15 @@ export const MAX_POSTPONE_WINDOW_DAYS = 30;
  * Batch size for bulk operations.
  */
 export const BATCH_SIZE = 500;
+
+/**
+ * Tag combination used by deck and flashcard queries when a deck's filters
+ * don't specify one.
+ *
+ * `"any"` because that is what these queries have always done -- the tag
+ * subquery matches an entry carrying any one of the deck's tags. Defaulting to
+ * `"all"` here would silently shrink every existing multi-tag deck, so decks
+ * saved before `tagMode` existed keep their current contents and only an
+ * explicit user choice changes them.
+ */
+export const DEFAULT_DECK_TAG_MODE: TagMode = "any";

--- a/packages/db-operations/src/operations/decks.test.ts
+++ b/packages/db-operations/src/operations/decks.test.ts
@@ -297,11 +297,89 @@ describe("decksTable", () => {
         expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(1);
       });
 
-      it("matches an entry that has ANY of several specified tags (OR)", async () => {
-        // Multi-tag filters are what surfaced the json_each perf bug; this
-        // pins down the OR semantics of the tag subquery.
+      it("treats an absent tagMode as OR, so decks saved before it keep their contents", async () => {
         const deck = await insertDeck(testDb, {
           filters: { tags: ["foo", "bar"] },
+        });
+
+        const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: fooEntry.id });
+
+        const bothEntry = await insertDictionaryEntry(testDb, {
+          tags: ["foo", "bar"],
+        });
+        await insertFlashcard(testDb, { dictionary_entry_id: bothEntry.id });
+
+        const decks = await decksTable.list.query({});
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(2);
+      });
+
+      it("requires every tag when tagMode is 'all'", async () => {
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"], tagMode: "all" },
+        });
+
+        const bothEntry = await insertDictionaryEntry(testDb, {
+          tags: ["foo", "bar"],
+        });
+        await insertFlashcard(testDb, { dictionary_entry_id: bothEntry.id });
+
+        // Carries one of the two, so it must not match under "all".
+        const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: fooEntry.id });
+
+        const decks = await decksTable.list.query({});
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(1);
+      });
+
+      it("still matches under 'all' when the entry carries extra tags", async () => {
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"], tagMode: "all" },
+        });
+
+        const entry = await insertDictionaryEntry(testDb, {
+          tags: ["foo", "bar", "baz"],
+        });
+        await insertFlashcard(testDb, { dictionary_entry_id: entry.id });
+
+        const decks = await decksTable.list.query({});
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(1);
+      });
+
+      it("returns nothing under 'all' for sibling tags no entry shares", async () => {
+        // The case BAH-187 is about: two tags at the same level of the
+        // hierarchy, where no single entry carries both.
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"], tagMode: "all" },
+        });
+
+        const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: fooEntry.id });
+
+        const barEntry = await insertDictionaryEntry(testDb, { tags: ["bar"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: barEntry.id });
+
+        const decks = await decksTable.list.query({});
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(0);
+      });
+
+      it("ignores a repeated filter tag under 'all'", async () => {
+        // The required-match count is built from DISTINCT filter tags, so a
+        // duplicate must not push the threshold past what any entry can reach.
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "foo"], tagMode: "all" },
+        });
+
+        const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
+        await insertFlashcard(testDb, { dictionary_entry_id: fooEntry.id });
+
+        const decks = await decksTable.list.query({});
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(1);
+      });
+
+      it("matches ANY of the tags when tagMode is explicitly 'any'", async () => {
+        const deck = await insertDeck(testDb, {
+          filters: { tags: ["foo", "bar"], tagMode: "any" },
         });
 
         const fooEntry = await insertDictionaryEntry(testDb, { tags: ["foo"] });
@@ -314,30 +392,7 @@ describe("decksTable", () => {
         await insertFlashcard(testDb, { dictionary_entry_id: bazEntry.id });
 
         const decks = await decksTable.list.query({});
-        const result = decks.find((d) => d.id === deck.id);
-
-        // foo + bar match, baz does not.
-        expect(result?.total_hits).toBe(2);
-      });
-
-      it("counts an entry with several matching tags only once", async () => {
-        // Regression guard for the tag filter rewrite: the subquery joins
-        // json_each(tags), so an entry matching multiple filter tags yields
-        // its id more than once inside the IN (...) set. total_hits is
-        // COUNT(DISTINCT flashcards.id), so the flashcard must still count once.
-        const deck = await insertDeck(testDb, {
-          filters: { tags: ["foo", "bar"] },
-        });
-
-        const bothEntry = await insertDictionaryEntry(testDb, {
-          tags: ["foo", "bar"],
-        });
-        await insertFlashcard(testDb, { dictionary_entry_id: bothEntry.id });
-
-        const decks = await decksTable.list.query({});
-        const result = decks.find((d) => d.id === deck.id);
-
-        expect(result?.total_hits).toBe(1);
+        expect(decks.find((d) => d.id === deck.id)?.total_hits).toBe(2);
       });
     });
 

--- a/packages/db-operations/src/operations/decks.ts
+++ b/packages/db-operations/src/operations/decks.ts
@@ -9,9 +9,13 @@ import {
 } from "@bahar/drizzle-user-db-schemas";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { nanoid } from "nanoid/non-secure";
-import { DEFAULT_BACKLOG_THRESHOLD_DAYS } from "../constants";
+import {
+  DEFAULT_BACKLOG_THRESHOLD_DAYS,
+  DEFAULT_DECK_TAG_MODE,
+} from "../constants";
 import { enqueueDbOperation } from "../queue";
 import type { TableOperation } from "../types";
+import { buildTagCondition } from "../utils";
 import type { OperationDeps } from "./deps";
 
 /**
@@ -54,6 +58,7 @@ export const makeDecksTable = ({
           decksList.map(async (deck) => {
             const {
               tags = [],
+              tagMode = DEFAULT_DECK_TAG_MODE,
               types: rawTypes,
               state: rawState,
             } = deck.filters ?? {};
@@ -75,18 +80,7 @@ export const makeDecksTable = ({
               inArray(dictionaryEntries.type, types),
               eq(flashcards.is_hidden, false),
               ...(tags.length > 0
-                ? [
-                    // Non-correlated subquery, not `EXISTS (json_each(...))`.
-                    // The correlated form re-runs json_each per candidate row,
-                    // which the WASM SQLite build evaluates pathologically
-                    // slowly for decks matching many rows (effectively hangs,
-                    // wedging the single connection). Materializing the matching
-                    // entry ids once keeps it in the tens of ms.
-                    sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${sql.join(
-                      tags.map((t) => sql`${t}`),
-                      sql`, `
-                    )}))`,
-                  ]
+                ? [buildTagCondition({ tags, mode: tagMode })]
                 : []),
             ];
 

--- a/packages/db-operations/src/operations/decks.ts
+++ b/packages/db-operations/src/operations/decks.ts
@@ -9,10 +9,7 @@ import {
 } from "@bahar/drizzle-user-db-schemas";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { nanoid } from "nanoid/non-secure";
-import {
-  DEFAULT_BACKLOG_THRESHOLD_DAYS,
-  DEFAULT_DECK_TAG_MODE,
-} from "../constants";
+import { DEFAULT_BACKLOG_THRESHOLD_DAYS, DEFAULT_TAG_MODE } from "../constants";
 import { enqueueDbOperation } from "../queue";
 import type { TableOperation } from "../types";
 import { buildTagCondition } from "../utils";
@@ -58,7 +55,7 @@ export const makeDecksTable = ({
           decksList.map(async (deck) => {
             const {
               tags = [],
-              tagMode = DEFAULT_DECK_TAG_MODE,
+              tagMode = DEFAULT_TAG_MODE,
               types: rawTypes,
               state: rawState,
             } = deck.filters ?? {};

--- a/packages/db-operations/src/operations/flashcards.ts
+++ b/packages/db-operations/src/operations/flashcards.ts
@@ -21,8 +21,8 @@ import { nanoid } from "nanoid/non-secure";
 import type { Grade, ReviewLog } from "ts-fsrs";
 import {
   DEFAULT_BACKLOG_THRESHOLD_DAYS,
-  DEFAULT_DECK_TAG_MODE,
   DEFAULT_POSTPONE_WINDOW_DAYS,
+  DEFAULT_TAG_MODE,
   MAX_POSTPONE_WINDOW_DAYS,
   MIN_POSTPONE_WINDOW_DAYS,
 } from "../constants";
@@ -215,7 +215,7 @@ const buildFilterConditions = ({
 }) => {
   const {
     tags = [],
-    tagMode = DEFAULT_DECK_TAG_MODE,
+    tagMode = DEFAULT_TAG_MODE,
     types: rawTypes,
     state: rawState,
   } = filters ?? {};

--- a/packages/db-operations/src/operations/flashcards.ts
+++ b/packages/db-operations/src/operations/flashcards.ts
@@ -21,12 +21,14 @@ import { nanoid } from "nanoid/non-secure";
 import type { Grade, ReviewLog } from "ts-fsrs";
 import {
   DEFAULT_BACKLOG_THRESHOLD_DAYS,
+  DEFAULT_DECK_TAG_MODE,
   DEFAULT_POSTPONE_WINDOW_DAYS,
   MAX_POSTPONE_WINDOW_DAYS,
   MIN_POSTPONE_WINDOW_DAYS,
 } from "../constants";
 import { enqueueDbOperation } from "../queue";
 import type { TableOperation } from "../types";
+import { buildTagCondition } from "../utils";
 import type { OperationDeps } from "./deps";
 import { makeProgressTable } from "./progress";
 
@@ -211,7 +213,12 @@ const buildFilterConditions = ({
 }: {
   filters?: SelectDeck["filters"];
 }) => {
-  const { tags = [], types: rawTypes, state: rawState } = filters ?? {};
+  const {
+    tags = [],
+    tagMode = DEFAULT_DECK_TAG_MODE,
+    types: rawTypes,
+    state: rawState,
+  } = filters ?? {};
 
   const types = rawTypes?.length ? rawTypes : [...WORD_TYPES];
   const state = rawState?.length
@@ -227,19 +234,7 @@ const buildFilterConditions = ({
     inArray(flashcards.state, state),
     inArray(dictionaryEntries.type, types),
     eq(flashcards.is_hidden, false),
-    ...(tags.length > 0
-      ? [
-          // Non-correlated subquery, not `EXISTS (json_each(...))`. The
-          // correlated form re-runs json_each per candidate row, which the WASM
-          // SQLite build evaluates pathologically slowly for filters matching
-          // many rows (effectively hangs, wedging the single connection).
-          // Materializing the matching entry ids once keeps it in the tens of ms.
-          sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${sql.join(
-            tags.map((t) => sql`${t}`),
-            sql`, `
-          )}))`,
-        ]
-      : []),
+    ...(tags.length > 0 ? [buildTagCondition({ tags, mode: tagMode })] : []),
   ];
 };
 

--- a/packages/db-operations/src/utils.ts
+++ b/packages/db-operations/src/utils.ts
@@ -2,12 +2,52 @@
  * SQL utility functions for database operations.
  */
 
+import {
+  dictionaryEntries,
+  type TagMode,
+} from "@bahar/drizzle-user-db-schemas";
+import { sql } from "drizzle-orm";
 import { nanoid } from "nanoid/non-secure";
 
 /**
  * Columns that contain JSON data and should not be escaped.
  */
 const JSON_COLUMNS = ["root", "tags", "antonyms", "examples", "morphology"];
+
+/**
+ * Restricts dictionary entries to those matching `tags`.
+ *
+ * Non-correlated subquery, not `EXISTS (json_each(...))`. The correlated form
+ * re-runs json_each per candidate row, which the WASM SQLite build evaluates
+ * pathologically slowly for filters matching many rows (effectively hangs,
+ * wedging the single connection). Materializing the matching entry ids once
+ * keeps it in the tens of ms.
+ *
+ * `"any"` matches entries carrying at least one of the tags, `"all"` requires
+ * every one. `all` counts DISTINCT values so an entry that repeats a tag in its
+ * JSON array still has to carry every filter tag, and the caller's tags are
+ * de-duplicated so a repeated filter tag doesn't inflate the required count
+ * past what any entry can reach.
+ */
+export const buildTagCondition = ({
+  tags,
+  mode,
+}: {
+  tags: string[];
+  mode: TagMode;
+}) => {
+  const uniqueTags = [...new Set(tags)];
+  const tagList = sql.join(
+    uniqueTags.map((tag) => sql`${tag}`),
+    sql`, `
+  );
+
+  if (mode === "all") {
+    return sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${tagList}) GROUP BY de_t.id HAVING COUNT(DISTINCT jt.value) = ${uniqueTags.length})`;
+  }
+
+  return sql`${dictionaryEntries.id} IN (SELECT de_t.id FROM dictionary_entries de_t, json_each(de_t.tags) jt WHERE jt.value IN (${tagList}))`;
+};
 
 /**
  * Generates a SQL json_object clause from column names.

--- a/packages/drizzle-user-db-schemas/src/types.ts
+++ b/packages/drizzle-user-db-schemas/src/types.ts
@@ -154,10 +154,10 @@ export type DeckFilters = {
    * How multiple tags combine. `"all"` requires every tag, `"any"` requires at
    * least one.
    *
-   * Absent means "keep what this surface already did", which differs by
-   * surface: deck and flashcard queries have always been `"any"`, while the
-   * dictionary search on the home screen has always been `"all"`. Resolve it
-   * against the caller's own default rather than assuming one here.
+   * Absent means `"any"` everywhere -- deck and flashcard queries have always
+   * behaved that way, and the dictionary search was moved onto the same
+   * default so a missing value means one thing rather than depending on which
+   * surface is asking.
    */
   tagMode?: TagMode;
   state?: FlashcardState[];

--- a/packages/drizzle-user-db-schemas/src/types.ts
+++ b/packages/drizzle-user-db-schemas/src/types.ts
@@ -144,8 +144,22 @@ export enum FlashcardState {
 }
 
 // Deck types
+export const TAG_MODES = ["all", "any"] as const;
+
+export type TagMode = (typeof TAG_MODES)[number];
+
 export type DeckFilters = {
   tags?: string[];
+  /**
+   * How multiple tags combine. `"all"` requires every tag, `"any"` requires at
+   * least one.
+   *
+   * Absent means "keep what this surface already did", which differs by
+   * surface: deck and flashcard queries have always been `"any"`, while the
+   * dictionary search on the home screen has always been `"all"`. Resolve it
+   * against the caller's own default rather than assuming one here.
+   */
+  tagMode?: TagMode;
   state?: FlashcardState[];
   types?: WordType[];
 };

--- a/packages/i18n/locales/ar.po
+++ b/packages/i18n/locales/ar.po
@@ -51,7 +51,7 @@ msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "تم توزيع {0} بطاقة على الأيام {windowDays} القادمة."
 
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:239
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
 msgid "{0} tags selected"
 msgstr "{0} علامات محددة"
 
@@ -323,7 +323,7 @@ msgstr "أضف صيغة جمع"
 msgid "Add Plural"
 msgstr "أضف جمع"
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:862
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:874
 msgid "Add some to get started!"
 msgstr "أضف شيئًا لتبدأ!"
 
@@ -477,7 +477,7 @@ msgstr "المظهر"
 msgid "Apple sign-in failed. Please try again."
 msgstr "فشل تسجيل الدخول باستخدام Apple. يرجى المحاولة مرة أخرى."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:487
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:494
 msgid "Apply"
 msgstr "تطبيق"
 
@@ -633,14 +633,14 @@ msgstr "بتسجيل الدخول، فإنك توافق على <0>سياسة ا�
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:482
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:489
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:97
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:219
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:221
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:138
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:305
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:307
 #: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:342
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:306
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:326
@@ -682,11 +682,11 @@ msgstr "السبب:"
 msgid "Choose file"
 msgstr "اختر ملف"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:538
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:545
 msgid "Clear"
 msgstr "امسح"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:273
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:274
 msgid "Clear all"
 msgstr "مسح الكل"
 
@@ -879,7 +879,7 @@ msgid "Customize how the application looks for you."
 msgstr "قم بتخصيص كيف يظهر التطبيق بالنسبة لك."
 
 #: ../../apps/mobile/src/app/(search)/settings.tsx:844
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:278
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:280
 msgid "Danger Zone"
 msgstr "منطقة الخطر"
 
@@ -937,8 +937,8 @@ msgstr "تم تحديث المجموعة"
 #: ../../apps/mobile/src/app/(search)/_layout.tsx:292
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:32
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:133
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:248
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:334
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:250
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:336
 msgid "Decks"
 msgstr "المجموعات"
 
@@ -993,7 +993,7 @@ msgstr "حذف الحساب"
 msgid "Delete All Data"
 msgstr "حذف جميع البيانات"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:296
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:298
 msgid "Delete Deck"
 msgstr "حذف المجموعة"
 
@@ -1127,7 +1127,7 @@ msgstr "حرّر {word}"
 
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:61
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:179
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:339
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:341
 msgid "Edit deck"
 msgstr "تعديل المجموعة"
 
@@ -1457,9 +1457,9 @@ msgstr "أدخل الكلمة والترجمة والنوع أولاً."
 msgid "Filter by tags..."
 msgstr "رشّح حسب العلامات..."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:164
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:264
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:520
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:166
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:527
 msgid "Filters"
 msgstr "الترشيح"
 
@@ -1627,7 +1627,7 @@ msgstr "مخفي"
 msgid "Hide details"
 msgstr "إخفاء التفاصيل"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:137
 msgid "Hide filters"
 msgstr "إخفاء المرشحات"
 
@@ -1993,7 +1993,7 @@ msgstr "لم يُستخدم بعد"
 msgid "New cards scheduled for review each day, in addition to any cards that are already due."
 msgstr "البطاقات الجديدة المقرر مراجعتها كل يوم، بالإضافة إلى أي بطاقات مستحقة بالفعل."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:253
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:255
 msgid "New deck"
 msgstr "مجموعة جديدة"
 
@@ -2051,7 +2051,7 @@ msgstr "لم يتم اختيار ملف"
 msgid "No overdue cards to reschedule."
 msgstr "لا توجد بطاقات متأخرة لإعادة جدولتها."
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:839
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:847
 #: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:87
 msgid "No results found"
 msgstr "لم يتم العثور على نتائج"
@@ -2061,7 +2061,7 @@ msgstr "لم يتم العثور على نتائج"
 msgid "No reviews yet today."
 msgstr "لا توجد مراجعات اليوم بعد."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:382
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:389
 msgid "No tags found"
 msgstr "لم يتم العثور على علامات"
 
@@ -2113,12 +2113,12 @@ msgstr "الأقدم"
 msgid "On"
 msgstr "تشغيل"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:272
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:278
 msgid "Only words that have every one of these tags will be included in the deck."
 msgstr ""
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:199
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:257
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:201
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:259
 msgid "Only words with every one of these tags will be included"
 msgstr ""
 
@@ -2182,7 +2182,7 @@ msgstr "نسبة مراجعات البطاقات الناضجة التي لم ي
 msgid "Permanently delete all your data including words, flashcards, and decks."
 msgstr "حذف جميع بياناتك نهائيًا بما في ذلك الكلمات والبطاقات والمجموعات."
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:283
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:285
 msgid "Permanently delete this deck. Your words and flashcards will not be affected."
 msgstr "حذف هذه المجموعة نهائياً. لن تتأثر كلماتك وبطاقاتك التعليمية."
 
@@ -2537,8 +2537,8 @@ msgstr "الحروف الأصلية"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:558
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:322
 #: ../../apps/web/src/components/features/settings/AdminSettingsCardSection.tsx:146
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:229
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:315
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:231
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:317
 #: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:352
 msgid "Save"
 msgstr "احفظ"
@@ -2547,7 +2547,7 @@ msgstr "احفظ"
 msgid "Save 30%"
 msgstr "وفّر ٣٠٪"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:380
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:386
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "حفظ التغييرات"
@@ -2569,7 +2569,7 @@ msgstr "ابحث عن علامة..."
 msgid "Search tag..."
 msgstr "ابحث عن علامة..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:333
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:340
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
@@ -2603,7 +2603,7 @@ msgstr "اختر إعرابا"
 msgid "Select Tags"
 msgstr "اختيار العلامات"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:323
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:329
 msgid "Select the types of words that you want to include in the deck."
 msgstr "حدد أنواع الكلمات التي تريد تضمينها في المجموعة."
 
@@ -2667,7 +2667,7 @@ msgstr "عرض التفاصيل"
 #~ msgid "Show English to Arabic flashcards."
 #~ msgstr "اعرض بطاقات من الإنجليزية إلى العربية."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:137
 msgid "Show filters"
 msgstr "عرض المرشحات"
 
@@ -2711,7 +2711,7 @@ msgid "Something went wrong. Please try again."
 msgstr "حدث خطأ ما. يرجى المحاولة مرة أخرى."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:431
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:438
 msgid "Sort by"
 msgstr "ترتيب حسب"
 
@@ -2803,10 +2803,10 @@ msgid "System"
 msgstr "نظام"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:328
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:173
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:181
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:286
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:287
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
@@ -3092,10 +3092,15 @@ msgstr "معرب"
 #~ msgid "Troubleshooting"
 #~ msgstr "استكشاف الأخطاء"
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:842
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:90
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:851
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:91
 msgid "Try a different search term"
 msgstr "جرب مصطلح بحث مختلف"
+
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:853
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:93
+msgid "Try adjusting your filters"
+msgstr ""
 
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:104
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:346
@@ -3107,7 +3112,7 @@ msgstr "إيقاف هذا يحذف البطاقة العكسية."
 msgid "Type"
 msgstr "الجنس"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:319
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:325
 msgid "Types"
 msgstr "أقسام"
 
@@ -3273,7 +3278,7 @@ msgid "Word not found"
 msgstr "الكلمة غير موجودة"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:393
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:400
 msgid "Word types"
 msgstr "أنواع الكلمات"
 
@@ -3300,17 +3305,15 @@ msgstr "الكلمات المضافة"
 msgid "Words Learned"
 msgstr "الكلمات المتعلّمة"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:210
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:322
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:328
 msgid "Words must have every selected tag."
 msgstr ""
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:212
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:324
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:330
 msgid "Words need only one of the selected tags."
 msgstr ""
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:283
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "الكلمات التي تحتوي على أي من هذه العلامات ستُدرج في المجموعة."
 
@@ -3323,8 +3326,8 @@ msgstr "الكلمات التي انتقلت من مرحلة التعلّم إل
 msgid "Words that have the opposite meaning."
 msgstr "الكلمات التي لها معنى عكسي."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:261
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:205
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:263
 msgid "Words with any of these tags will be included"
 msgstr "سيتم تضمين الكلمات التي تحمل أياً من هذه العلامات"
 
@@ -3373,7 +3376,7 @@ msgstr "ليس لديك أي مجموعات بعد."
 msgid "You have no overdue cards to reschedule."
 msgstr "ليس لديك بطاقات متأخرة لإعادة جدولتها."
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:859
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:871
 msgid "You have no words in your dictionary yet."
 msgstr "ليس لديك أي كلمات في معجمك بعد."
 

--- a/packages/i18n/locales/ar.po
+++ b/packages/i18n/locales/ar.po
@@ -51,7 +51,7 @@ msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "تم توزيع {0} بطاقة على الأيام {windowDays} القادمة."
 
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:215
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:239
 msgid "{0} tags selected"
 msgstr "{0} علامات محددة"
 
@@ -171,7 +171,7 @@ msgstr "{totalHits, plural, one {نتيجة} two {نتيجتان} few {نتائ�
 
 #. placeholder {0}: formatNumber(totalResults)
 #. placeholder {1}: formatNumber(totalResults)
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:126
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:127
 msgid "{totalResults, plural, one {{0} result} other {{1} results}}"
 msgstr "{totalResults, plural, one {{0} نتيجة} two {{0} نتيجتان} few {{0} نتائج} many {{0} نتيجة} other {{1} نتيجة}}"
 
@@ -221,7 +221,7 @@ msgstr "متوسط ٧ أيام"
 msgid "90 days"
 msgstr "٩٠ يومًا"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:57
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:65
 msgid "A new version is ready to install."
 msgstr "إصدار جديد جاهز للتثبيت."
 
@@ -268,8 +268,8 @@ msgstr "اسم فاعل"
 msgid "Add a new SQL migration."
 msgstr "أضف ترحيل SQL جديد."
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:88
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:241
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:92
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:255
 msgid "Add a new word"
 msgstr "أضف كلمة جديدة"
 
@@ -327,7 +327,7 @@ msgstr "أضف جمع"
 msgid "Add some to get started!"
 msgstr "أضف شيئًا لتبدأ!"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:68
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:70
 msgid "Add some words to get started!"
 msgstr "أضف بعض الكلمات للبدء!"
 
@@ -345,8 +345,8 @@ msgstr "أضف علامات إلى كلمتك."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:105
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:72
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:150
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:63
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:151
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:67
 msgid "Add word"
 msgstr "أضف كلمة"
 
@@ -446,15 +446,15 @@ msgstr "أية صيغ جمع للكلمة."
 msgid "Any words that have the same ID will be overwritten."
 msgstr "سيستبدل كل كلمات التي لديها نفس المعرف."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:421
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:427
 msgid "Anything using this key stops working immediately. This can't be undone."
 msgstr "سيتوقف فورًا كل ما يستخدم هذا المفتاح. لا يمكن التراجع عن هذا الإجراء."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:342
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:348
 msgid "API key revoked"
 msgstr "تم إبطال مفتاح الواجهة البرمجية"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:461
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:467
 #: ../../apps/mobile/src/app/(search)/settings.tsx:638
 msgid "API keys"
 msgstr "مفاتيح الواجهة البرمجية"
@@ -477,7 +477,7 @@ msgstr "المظهر"
 msgid "Apple sign-in failed. Please try again."
 msgstr "فشل تسجيل الدخول باستخدام Apple. يرجى المحاولة مرة أخرى."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:426
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:487
 msgid "Apply"
 msgstr "تطبيق"
 
@@ -521,7 +521,7 @@ msgstr "الكلمة بالعربية"
 msgid "Are you sure you want to delete this word? It will be removed from your dictionary and its flashcards will be deleted.<0/><1/><2>This action cannot be undone.</2>"
 msgstr "هل أنت متأكد أنك تريد حذف هذه الكلمة؟ سيتم إزالتها من معجمك وسيتم حذف البطاقات بها.<0/><1/><2>لا يمكن التراجع عن هذا الإجراء.</2>"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:298
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:304
 msgid "Are you sure you want to delete this word? This action cannot be undone."
 msgstr "هل أنت متأكد من حذف هذه الكلمة؟ لا يمكن التراجع عن هذا الإجراء."
 
@@ -529,7 +529,7 @@ msgstr "هل أنت متأكد من حذف هذه الكلمة؟ لا يمكن �
 msgid "Are you sure you want to delete your dictionary? All your words will be deleted permanently. This action cannot be undone. Please make sure to export your dictionary before deleting it."
 msgstr "هل أنت متأكد من رغبتك في حذف معجمك؟ سيحذف جميع كلماتك بشكل دائم. لا يمكن التراجع عن هذا الإجراء. صدر معجمك قبل حذفه من فضلك."
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:318
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:324
 msgid "Are you sure you want to reset the flashcard for this word? This will reset all spaced repetition progress."
 msgstr "هل أنت متأكد من إعادة تعيين البطاقة لهذه الكلمة؟ سيتم إعادة تعيين كل تقدم التكرار المتباعد."
 
@@ -630,21 +630,21 @@ msgstr "بتسجيل الدخول، فإنك توافق على <0>سياسة ا�
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:691
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:748
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:248
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:437
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:421
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:482
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:97
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:117
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:252
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:324
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:300
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:320
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:432
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:219
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:138
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:305
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:342
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:306
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:326
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:450
 msgid "Cancel"
 msgstr "ألغ"
 
@@ -682,15 +682,15 @@ msgstr "السبب:"
 msgid "Choose file"
 msgstr "اختر ملف"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:477
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:538
 msgid "Clear"
 msgstr "امسح"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:249
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:273
 msgid "Clear all"
 msgstr "مسح الكل"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:310
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:368
 msgid "Clear all filters"
 msgstr "مسح كل المرشّحات"
 
@@ -771,7 +771,7 @@ msgstr "تم النسخ!"
 msgid "Copy"
 msgstr "انسخ"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:297
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:302
 msgid "Copy API key"
 msgstr "نسخ مفتاح الواجهة البرمجية"
 
@@ -779,7 +779,7 @@ msgstr "نسخ مفتاح الواجهة البرمجية"
 msgid "Copy it now — you won't be able to see it again. Anyone with this key can read and write your dictionary."
 msgstr "انسخه الآن — لن تتمكن من رؤيته مرة أخرى. يمكن لأي شخص يملك هذا المفتاح قراءة قاموسك والكتابة فيه."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:475
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:481
 msgid "Couldn't load your API keys. Please try again later."
 msgstr "تعذّر تحميل مفاتيح الواجهة البرمجية. يُرجى المحاولة لاحقًا."
 
@@ -796,18 +796,18 @@ msgstr "إنشاء \"{0}\""
 #~ msgid "Create a deck to organize your flashcard reviews"
 #~ msgstr "أنشئ مجموعة لتنظيم مراجعات بطاقاتك"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:77
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:46
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:103
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:81
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:59
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:121
 msgid "Create a new deck"
 msgstr "إنشاء مجموعة جديدة"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:81
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:85
 msgid "Create a new deck by choosing filters. The deck will be composed of the cards that match the filters."
 msgstr "أنشئ مجموعة جديدة باختيار الفلاتر. ستكون المجموعة مكونة من البطاقات التي تطابق هذه الفلاتر."
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:472
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:273
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:287
 msgid "Create a reverse card"
 msgstr "إنشاء بطاقة عكسية"
 
@@ -837,14 +837,14 @@ msgstr "أنشئ مجموعة"
 #~ msgstr "إنشاء مجموعة"
 
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:243
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:504
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:510
 msgid "Create key"
 msgstr "إنشاء مفتاح"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:512
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:539
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:306
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:313
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:324
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:331
 msgid "Create multiple"
 msgstr "إضافة متعددة"
 
@@ -879,7 +879,7 @@ msgid "Customize how the application looks for you."
 msgstr "قم بتخصيص كيف يظهر التطبيق بالنسبة لك."
 
 #: ../../apps/mobile/src/app/(search)/settings.tsx:844
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:225
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:278
 msgid "Danger Zone"
 msgstr "منطقة الخطر"
 
@@ -901,20 +901,20 @@ msgstr "يوم"
 msgid "Debugging"
 msgstr "استكشاف الأخطاء"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:59
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:74
 msgid "Deck created"
 msgstr "تم إنشاء المجموعة"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:95
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:113
 msgid "Deck deleted"
 msgstr "تم حذف المجموعة"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:111
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:166
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:129
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:187
 msgid "Deck Name"
 msgstr "اسم المجموعة"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:168
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:182
 msgid "Deck successfully created!"
 msgstr "تم إنشاء المجموعة بنجاح!"
 
@@ -922,11 +922,11 @@ msgstr "تم إنشاء المجموعة بنجاح!"
 msgid "Deck successfully deleted!"
 msgstr "تم حذف المجموعة بنجاح!"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:164
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:178
 msgid "Deck successfully updated!"
 msgstr "تم تحديث المجموعة بنجاح!"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:82
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:100
 msgid "Deck updated"
 msgstr "تم تحديث المجموعة"
 
@@ -934,11 +934,11 @@ msgstr "تم تحديث المجموعة"
 #: ../../apps/web/src/components/MobileHeader.tsx:166
 #: ../../apps/web/src/components/DesktopNavigation.tsx:69
 #: ../../apps/web/src/components/DesktopNavigation.tsx:75
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:283
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:292
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:32
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:133
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:198
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:281
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:248
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:334
 msgid "Decks"
 msgstr "المجموعات"
 
@@ -964,8 +964,8 @@ msgstr "التعريف"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/decks/route.lazy.tsx:191
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:80
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:89
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:119
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:302
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:140
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:308
 msgid "Delete"
 msgstr "احذف"
 
@@ -974,7 +974,7 @@ msgstr "احذف"
 msgid "Delete \"{0}\"?"
 msgstr "حذف \"{0}\"؟"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:114
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:135
 msgid "Delete \"{name}\"?"
 msgstr "حذف \"{name}\"؟"
 
@@ -993,7 +993,7 @@ msgstr "حذف الحساب"
 msgid "Delete All Data"
 msgstr "حذف جميع البيانات"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:243
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:296
 msgid "Delete Deck"
 msgstr "حذف المجموعة"
 
@@ -1009,7 +1009,7 @@ msgstr "حذف كل شيء"
 msgid "Delete this word?"
 msgstr "حذف هذه الكلمة؟"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:297
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:303
 msgid "Delete word"
 msgstr "حذف الكلمة"
 
@@ -1073,12 +1073,12 @@ msgstr "اغلق"
 msgid "Don't show"
 msgstr "لا تعرض"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:309
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:315
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:190
 msgid "Done"
 msgstr "تم"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:83
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:91
 msgid "Downloading update"
 msgstr "جارٍ تنزيل التحديث"
 
@@ -1093,8 +1093,8 @@ msgstr "المثنى"
 msgid "due"
 msgstr "مستحقة"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:118
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:173
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:136
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:194
 msgid "e.g. Essential Vocabulary"
 msgstr "مثال: المفردات الأساسية"
 
@@ -1125,9 +1125,9 @@ msgstr "عدَل"
 msgid "Edit {word}"
 msgstr "حرّر {word}"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:48
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:158
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:286
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:61
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:179
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:339
 msgid "Edit deck"
 msgstr "تعديل المجموعة"
 
@@ -1135,17 +1135,17 @@ msgstr "تعديل المجموعة"
 #~ msgid "Edit Deck"
 #~ msgstr "تعديل المجموعة"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:62
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:89
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:377
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:66
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:93
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:391
 msgid "Edit word"
 msgstr "تعديل الكلمة"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:94
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:98
 msgid "Edit your deck"
 msgstr "عدّل مجموعتك"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:98
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:102
 msgid "Edit your deck by choosing filters. The deck will be composed of the cards that match the filters."
 msgstr "عدّل مجموعتك من خلال اختيار الفلاتر. ستتكون المجموعة من البطاقات التي تطابق الفلاتر."
 
@@ -1174,7 +1174,7 @@ msgstr "إنجليزي → عربي"
 msgid "English → Arabic, for this word."
 msgstr "إنجليزي → عربي، لهذه الكلمة."
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:276
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:290
 msgid "English to Arabic, for this word."
 msgstr "من الإنجليزية إلى العربية، لهذه الكلمة."
 
@@ -1183,7 +1183,7 @@ msgstr "من الإنجليزية إلى العربية، لهذه الكلمة.
 msgid "English translation"
 msgstr "الترجمة بالإنجليزية"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:210
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:224
 msgid "Enter a deck name"
 msgstr "أدخل اسم المجموعة"
 
@@ -1234,12 +1234,12 @@ msgstr "استخدامات مثالية للكلمة في سياقات مختل�
 msgid "Examples"
 msgstr "أمثلة"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:384
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:390
 msgid "Expired"
 msgstr "منتهي الصلاحية"
 
 #. placeholder {0}: intlFormatDistance(expiresAt, now, { locale: i18n.locale, }).label
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:386
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:392
 msgid "Expires {0}"
 msgstr "تنتهي صلاحيته {0}"
 
@@ -1278,21 +1278,21 @@ msgstr "تصدير المعجم مع البطاقات سيحفظ تقدم الب
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:50
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:17
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:69
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:74
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:136
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:468
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:73
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:475
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:15
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:72
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:42
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:9
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:19
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:39
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:40
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:44
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:45
 msgid "Expression"
 msgstr "عبارة"
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:145
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:151
 msgid "Failed to add word"
 msgstr "فشل إضافة الكلمة"
 
@@ -1318,7 +1318,7 @@ msgstr "فشل الملء التلقائي"
 msgid "Failed to create API key"
 msgstr "فشل إنشاء مفتاح الواجهة البرمجية"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:63
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:78
 msgid "Failed to create deck"
 msgstr "فشل إنشاء المجموعة"
 
@@ -1336,7 +1336,7 @@ msgstr "فشل حذف الحساب"
 msgid "Failed to delete dictionary"
 msgstr "فشل حذف المعجم"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:140
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:146
 msgid "Failed to delete word"
 msgstr "فشل حذف الكلمة"
 
@@ -1361,7 +1361,7 @@ msgstr "فشل توليد المثال"
 msgid "Failed to reschedule backlog"
 msgstr "فشل في إعادة جدولة المتراكمات"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:187
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:193
 msgid "Failed to reset flashcard"
 msgstr "فشل إعادة تعيين البطاقة"
 
@@ -1377,11 +1377,11 @@ msgstr "فشل في استرجاع البيانات من قاعدة البيان
 msgid "Failed to retrieve database information."
 msgstr "فشل استرجاع معلومات قاعدة البيانات."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:344
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:350
 msgid "Failed to revoke API key"
 msgstr "فشل إبطال مفتاح الواجهة البرمجية"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:86
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:104
 msgid "Failed to update deck"
 msgstr "فشل تحديث المجموعة"
 
@@ -1405,7 +1405,7 @@ msgstr "فشل تحديث الإعدادات"
 msgid "Failed to update the word!"
 msgstr "فشل في تحديث الكلمة!"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:123
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:129
 msgid "Failed to update word"
 msgstr "فشل تحديث الكلمة"
 
@@ -1423,18 +1423,18 @@ msgstr "مؤنّث"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:48
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:13
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:67
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:72
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:90
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:130
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:65
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:464
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:471
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:13
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:70
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:76
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:40
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:7
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:17
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:37
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:38
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:42
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:43
 msgid "Fi'l"
 msgstr "فعل"
 
@@ -1457,13 +1457,13 @@ msgstr "أدخل الكلمة والترجمة والنوع أولاً."
 msgid "Filter by tags..."
 msgstr "رشّح حسب العلامات..."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:146
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:459
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:164
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:264
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:520
 msgid "Filters"
 msgstr "الترشيح"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:184
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:190
 msgid "Flashcard reset successfully"
 msgstr "تم إعادة تعيين البطاقة بنجاح"
 
@@ -1475,8 +1475,8 @@ msgstr "تم تحديث إعدادات البطاقة!"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:461
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:224
 #: ../../apps/mobile/src/app/(search)/settings.tsx:673
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:269
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:422
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:283
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:436
 msgid "Flashcards"
 msgstr "بطاقات"
 
@@ -1550,7 +1550,7 @@ msgstr "ابدأ"
 #~ msgstr "GitHub"
 
 #: ../../apps/web/src/components/OTPForm.tsx:129
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:353
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:359
 msgid "Go back"
 msgstr "ارجع"
 
@@ -1593,19 +1593,19 @@ msgstr "صعب"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:49
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:15
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:68
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:73
 #: ../../apps/web/src/components/features/dictionary/add/VerbMorphologyCardSection.tsx:350
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:101
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:133
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:466
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:71
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:473
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:14
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:71
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:41
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:8
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:18
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:38
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:39
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:43
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:44
 msgid "Harf"
 msgstr "حرف"
 
@@ -1627,7 +1627,7 @@ msgstr "مخفي"
 msgid "Hide details"
 msgstr "إخفاء التفاصيل"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:117
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
 msgid "Hide filters"
 msgstr "إخفاء المرشحات"
 
@@ -1640,9 +1640,9 @@ msgstr "تلميح"
 #: ../../apps/web/src/components/MobileHeader.tsx:154
 #: ../../apps/web/src/components/DesktopNavigation.tsx:53
 #: ../../apps/web/src/components/DesktopNavigation.tsx:59
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:272
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:58
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:57
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:281
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:62
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:61
 msgid "Home"
 msgstr "منزل"
 
@@ -1750,18 +1750,18 @@ msgstr "قيمة غير صالحة. يجب أن تكون إحدى القيم ا�
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:47
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:11
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:66
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:71
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:76
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:127
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:63
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:462
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:469
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:12
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:69
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:75
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:39
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:6
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:16
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:36
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:37
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:41
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:42
 msgid "Ism"
 msgstr "اسم"
 
@@ -1771,11 +1771,11 @@ msgstr "اسم"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:516
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:543
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:314
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:332
 msgid "Keep adding words after saving instead of going back to the homepage."
 msgstr "استمر في إضافة كلمات بعد الحفظ بدلاً من العودة إلى الصفحة الرئيسية."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:465
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:471
 msgid "Keys let the Bahar CLI and other tools read and write your dictionary on your behalf."
 msgstr "تتيح المفاتيح لأداة بهار الطرفية وغيرها من الأدوات قراءة قاموسك والكتابة فيه نيابة عنك."
 
@@ -1785,7 +1785,7 @@ msgid "Language"
 msgstr "اللغة"
 
 #. placeholder {0}: intlFormatDistance(lastRequest, now, { locale: i18n.locale, }).label
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:369
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:375
 msgid "Last used {0}"
 msgstr "آخر استخدام {0}"
 
@@ -1807,16 +1807,16 @@ msgstr "فاتح"
 msgid "Loading details..."
 msgstr "جارٍ تحميل التفاصيل..."
 
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:282
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:284
 msgid "Loading your dictionary..."
 msgstr "جارٍ تحميل معجمك..."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:87
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:142
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:143
 msgid "Loading..."
 msgstr "جارٍ التحميل..."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:481
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:487
 msgid "Loading…"
 msgstr "جارٍ التحميل…"
 
@@ -1831,7 +1831,7 @@ msgstr "قم بتسجيل الدخول إلى حسابك الحالي أو قم 
 
 #: ../../apps/web/src/components/MobileHeader.tsx:203
 #: ../../apps/web/src/components/DesktopNavigation.tsx:135
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:180
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:187
 msgid "Logout"
 msgstr "تسجيل الخروج"
 
@@ -1893,6 +1893,22 @@ msgstr "مصدر"
 msgid "Masdar {0}"
 msgstr "المصدر {0}"
 
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:81
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:161
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:85
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:51
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:52
+msgid "Match all"
+msgstr ""
+
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:82
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:162
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:86
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:52
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:53
+msgid "Match any"
+msgstr ""
+
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:251
 msgid "Matching tags"
 msgstr "علامات مطابقة"
@@ -1937,8 +1953,8 @@ msgstr "الصرف"
 msgid "Morphology only applies to isms and fi'ls. This section will be hidden if the type of the word is set to anything else."
 msgstr "الصرف ينطبق فقط على الأسماء والأفعال. سيتم إخفاء هذا القسم إذا تم تعيين نوع الكلمة إلى أي شيء آخر."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:47
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:61
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:52
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
 msgid "Most difficult"
 msgstr "الأصعب"
 
@@ -1952,7 +1968,7 @@ msgstr "وكيلي"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/decks/route.lazy.tsx:102
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:168
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:203
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:217
 msgid "Name"
 msgstr "اسم"
 
@@ -1964,11 +1980,11 @@ msgstr "قائمة التنقل"
 msgid "Never"
 msgstr "أبدًا"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:396
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:402
 msgid "Never expires"
 msgstr "لا تنتهي صلاحيته"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:378
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:384
 msgid "Never used"
 msgstr "لم يُستخدم بعد"
 
@@ -1977,7 +1993,7 @@ msgstr "لم يُستخدم بعد"
 msgid "New cards scheduled for review each day, in addition to any cards that are already due."
 msgstr "البطاقات الجديدة المقرر مراجعتها كل يوم، بالإضافة إلى أي بطاقات مستحقة بالفعل."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:253
 msgid "New deck"
 msgstr "مجموعة جديدة"
 
@@ -2036,7 +2052,7 @@ msgid "No overdue cards to reschedule."
 msgstr "لا توجد بطاقات متأخرة لإعادة جدولتها."
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:839
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:85
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:87
 msgid "No results found"
 msgstr "لم يتم العثور على نتائج"
 
@@ -2045,7 +2061,7 @@ msgstr "لم يتم العثور على نتائج"
 msgid "No reviews yet today."
 msgstr "لا توجد مراجعات اليوم بعد."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:321
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:382
 msgid "No tags found"
 msgstr "لم يتم العثور على علامات"
 
@@ -2081,7 +2097,7 @@ msgstr "الآن"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:489
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:94
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:337
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:283
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:297
 msgid "Off"
 msgstr "إيقاف"
 
@@ -2093,9 +2109,18 @@ msgstr "الأقدم"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:492
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:97
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:338
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:284
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:298
 msgid "On"
 msgstr "تشغيل"
+
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:272
+msgid "Only words that have every one of these tags will be included in the deck."
+msgstr ""
+
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:199
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:257
+msgid "Only words with every one of these tags will be included"
+msgstr ""
 
 #: ../../apps/mobile/src/app/(search)/stats.tsx:37
 #~ msgid "Open web app"
@@ -2157,7 +2182,7 @@ msgstr "نسبة مراجعات البطاقات الناضجة التي لم ي
 msgid "Permanently delete all your data including words, flashcards, and decks."
 msgstr "حذف جميع بياناتك نهائيًا بما في ذلك الكلمات والبطاقات والمجموعات."
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:230
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:283
 msgid "Permanently delete this deck. Your words and flashcards will not be affected."
 msgstr "حذف هذه المجموعة نهائياً. لن تتأثر كلماتك وبطاقاتك التعليمية."
 
@@ -2193,7 +2218,7 @@ msgstr "يرجى تسجيل الدخول مرة أخرى لحذف حسابك"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:223
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:239
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:134
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:345
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:351
 msgid "Please try again later."
 msgstr "يرجى المحاولة لاحقاً."
 
@@ -2291,7 +2316,7 @@ msgstr "برو"
 #: ../../apps/web/src/components/DesktopNavigation.tsx:91
 #: ../../apps/mobile/src/app/(search)/stats.tsx:31
 #: ../../apps/mobile/src/app/(search)/stats.tsx:272
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:294
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:303
 msgid "Progress"
 msgstr "التقدّم"
 
@@ -2320,18 +2345,18 @@ msgstr "تلقّي تحديثات المنتج والنصائح وإعلانات
 msgid "Recent Reviews"
 msgstr "المراجعات الأخيرة"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:45
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:60
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:50
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
 msgid "Recently added"
 msgstr "المضافة حديثًا"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:49
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:62
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:54
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
 msgid "Recently reviewed"
 msgstr "المراجَعة حديثًا"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:43
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:59
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:48
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:65
 msgid "Recently updated"
 msgstr "المحدّثة حديثًا"
 
@@ -2344,8 +2369,8 @@ msgstr "المستخدمة مؤخرًا"
 msgid "Regular reviews done!"
 msgstr "انتهت المراجعات العادية!"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:41
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:58
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:46
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:64
 msgid "Relevance"
 msgstr "الصلة"
 
@@ -2390,7 +2415,7 @@ msgstr "أعد جدولة المتراكمات"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:468
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:89
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:322
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:328
 msgid "Reset"
 msgstr "إعادة تعيين"
 
@@ -2400,7 +2425,7 @@ msgstr "إعادة التعيين والمزامنة"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx:106
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx:140
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:317
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:323
 msgid "Reset flashcard"
 msgstr "أعد البطاقة"
 
@@ -2445,7 +2470,7 @@ msgstr "بطاقة عكسية"
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:128
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/FlashcardDrawer.tsx:328
 #: ../../apps/mobile/src/components/flashcards/FlashcardReview.tsx:86
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:166
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:167
 msgid "Review"
 msgstr "مراجعة"
 
@@ -2481,16 +2506,16 @@ msgstr "راجع بطاقاتك العربية وقيم فهمك باستخدا�
 msgid "Reviews"
 msgstr "مراجعات"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:410
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:431
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:416
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:437
 msgid "Revoke"
 msgstr "إبطال"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:406
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:412
 msgid "Revoke {label}"
 msgstr "إبطال {label}"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:417
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:423
 msgid "Revoke this API key?"
 msgstr "إبطال مفتاح الواجهة البرمجية هذا؟"
 
@@ -2512,9 +2537,9 @@ msgstr "الحروف الأصلية"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:558
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:322
 #: ../../apps/web/src/components/features/settings/AdminSettingsCardSection.tsx:146
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:179
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:262
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:334
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:229
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:315
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:352
 msgid "Save"
 msgstr "احفظ"
 
@@ -2522,8 +2547,8 @@ msgstr "احفظ"
 msgid "Save 30%"
 msgstr "وفّر ٣٠٪"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:334
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:442
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:380
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "حفظ التغييرات"
 
@@ -2544,14 +2569,14 @@ msgstr "ابحث عن علامة..."
 msgid "Search tag..."
 msgstr "ابحث عن علامة..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:272
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:333
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
 msgstr "البحث في العلامات..."
 
 #: ../../apps/web/src/components/search/SearchInput.tsx:63
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:128
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:135
 msgid "Search..."
 msgstr "ابحث..."
 
@@ -2578,7 +2603,7 @@ msgstr "اختر إعرابا"
 msgid "Select Tags"
 msgstr "اختيار العلامات"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:323
 msgid "Select the types of words that you want to include in the deck."
 msgstr "حدد أنواع الكلمات التي تريد تضمينها في المجموعة."
 
@@ -2588,8 +2613,8 @@ msgstr "حدد أنواع الكلمات التي تريد تضمينها في �
 msgid "Select type"
 msgstr "اختر الجنس"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:132
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:187
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:150
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:208
 msgid "Select which types of words to include"
 msgstr "اختر أنواع الكلمات المراد تضمينها"
 
@@ -2610,7 +2635,7 @@ msgstr "افصل الحروف بمسافات أو فواصل"
 #: ../../apps/web/src/components/DesktopNavigation.tsx:123
 #: ../../apps/mobile/src/app/(search)/settings.tsx:254
 #: ../../apps/mobile/src/app/(search)/settings.tsx:556
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:305
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:314
 msgid "Settings"
 msgstr "الإعدادات"
 
@@ -2642,7 +2667,7 @@ msgstr "عرض التفاصيل"
 #~ msgid "Show English to Arabic flashcards."
 #~ msgstr "اعرض بطاقات من الإنجليزية إلى العربية."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:117
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
 msgid "Show filters"
 msgstr "عرض المرشحات"
 
@@ -2674,7 +2699,7 @@ msgid "Some dictionary entries couldn't be loaded"
 msgstr "تعذر تحميل بعض إدخالات المعجم"
 
 #: ../../apps/web/src/routes/cli-auth/route.lazy.tsx:51
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:292
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:294
 msgid "Something went wrong"
 msgstr "حدث خطأ ما"
 
@@ -2685,8 +2710,8 @@ msgstr "حدث خطأ ما"
 msgid "Something went wrong. Please try again."
 msgstr "حدث خطأ ما. يرجى المحاولة مرة أخرى."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:246
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:370
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:431
 msgid "Sort by"
 msgstr "ترتيب حسب"
 
@@ -2778,15 +2803,15 @@ msgid "System"
 msgstr "نظام"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:328
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:155
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:173
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:229
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:262
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:286
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:151
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:206
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:259
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:412
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:273
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:426
 msgid "Tags"
 msgstr "علامات"
 
@@ -2882,7 +2907,7 @@ msgstr "حدث خطأ أثناء إضافة كلمتك. حاول مرة اخرى
 #~ msgid "There was an error clearing your backlog."
 #~ msgstr "حدث خطأ أثناء مسح المتراكمات."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:180
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:194
 msgid "There was an error creating the deck"
 msgstr "حدث خطأ أثناء إنشاء المجموعة"
 
@@ -2915,7 +2940,7 @@ msgstr "حدث خطأ أثناء إعادة جدولة المتراكمات."
 #~ msgid "There was an error syncing your data. Your local data is still available."
 #~ msgstr "حدث خطأ في مزامنة بياناتك. بياناتك المحلية لا تزال متاحة."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:176
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:190
 msgid "There was an error updating the deck"
 msgstr "حدث خطأ أثناء تحديث المجموعة"
 
@@ -2945,7 +2970,7 @@ msgid "There's a temporary issue loading your account. Please try reloading the 
 msgstr "هناك مشكلة مؤقتة في تحميل حسابك. حاول إعادة تحميل الصفحة من فضلك."
 
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:85
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:115
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:136
 msgid "This cannot be undone. Your words and flashcards will not be affected."
 msgstr "لا يمكن التراجع عن هذا الإجراء. لن تتأثر كلماتك وبطاقاتك التعليمية."
 
@@ -2974,7 +2999,7 @@ msgstr "هذه الخانة لازم."
 msgid "This is case insensitive."
 msgstr "هذا حالة غير حساسة."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:217
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:231
 msgid "This is the name of your deck."
 msgstr "هذا هو اسم مجموعتك."
 
@@ -3068,7 +3093,7 @@ msgstr "معرب"
 #~ msgstr "استكشاف الأخطاء"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:842
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:88
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:90
 msgid "Try a different search term"
 msgstr "جرب مصطلح بحث مختلف"
 
@@ -3082,7 +3107,7 @@ msgstr "إيقاف هذا يحذف البطاقة العكسية."
 msgid "Type"
 msgstr "الجنس"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:273
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:319
 msgid "Types"
 msgstr "أقسام"
 
@@ -3109,7 +3134,7 @@ msgstr "خطأ غير معروف."
 msgid "Unlock Insights"
 msgstr "فتح الإحصائيات"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:356
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:362
 msgid "Unnamed key"
 msgstr "مفتاح بلا اسم"
 
@@ -3118,11 +3143,11 @@ msgstr "مفتاح بلا اسم"
 msgid "Unsubscribed from marketing emails"
 msgstr "تم إلغاء الاشتراك من رسائل البريد التسويقية"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:67
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:75
 msgid "Update"
 msgstr "حدّث"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:53
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:61
 msgid "Update available"
 msgstr "يتوفر تحديث"
 
@@ -3235,29 +3260,29 @@ msgstr "مرحباً بكم في بحر!"
 msgid "Word"
 msgstr "الكلمة"
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:136
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:142
 msgid "Word added successfully"
 msgstr "تمت إضافة الكلمة بنجاح"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:136
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:142
 msgid "Word deleted successfully"
 msgstr "تم حذف الكلمة بنجاح"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:350
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:356
 msgid "Word not found"
 msgstr "الكلمة غير موجودة"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:203
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:332
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:393
 msgid "Word types"
 msgstr "أنواع الكلمات"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:129
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:184
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:147
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:205
 msgid "Word Types"
 msgstr "أنواع الكلمات"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:119
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:125
 msgid "Word updated successfully"
 msgstr "تم تحديث الكلمة بنجاح"
 
@@ -3275,7 +3300,17 @@ msgstr "الكلمات المضافة"
 msgid "Words Learned"
 msgstr "الكلمات المتعلّمة"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:210
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:322
+msgid "Words must have every selected tag."
+msgstr ""
+
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:212
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:324
+msgid "Words need only one of the selected tags."
+msgstr ""
+
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "الكلمات التي تحتوي على أي من هذه العلامات ستُدرج في المجموعة."
 
@@ -3288,8 +3323,8 @@ msgstr "الكلمات التي انتقلت من مرحلة التعلّم إل
 msgid "Words that have the opposite meaning."
 msgstr "الكلمات التي لها معنى عكسي."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:154
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:209
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:261
 msgid "Words with any of these tags will be included"
 msgstr "سيتم تضمين الكلمات التي تحمل أياً من هذه العلامات"
 
@@ -3315,7 +3350,7 @@ msgstr "يمكنك إغلاق علامة التبويب هذه بمجرد أن �
 msgid "You do not have access to upload schema migrations."
 msgstr "ليس لديك إذن لتحميل ترحيلات المخطط."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:487
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:493
 msgid "You don't have any API keys yet. Signing in with `bahar login` creates one for you."
 msgstr "ليس لديك أي مفاتيح واجهة برمجية بعد. تسجيل الدخول عبر `bahar login` يُنشئ لك مفتاحًا."
 
@@ -3370,16 +3405,16 @@ msgstr "رفيقك لتعلم اللغة العربية"
 #~ msgid "Your data has been re-synced from the server."
 #~ msgstr "تمت إعادة مزامنة بياناتك من الخادم."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:181
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:195
 msgid "Your deck was not created. Please try again."
 msgstr "لم يتم إنشاء مجموعتك. يرجى المحاولة مرة أخرى."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:177
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:191
 msgid "Your deck was not updated. Please try again."
 msgstr "لم يتم تحديث مجموعتك. يرجى المحاولة مرة أخرى."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:63
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:121
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:122
 msgid "Your Dictionary"
 msgstr "معجمك"
 
@@ -3395,7 +3430,7 @@ msgstr "تم تحميل معجمك."
 msgid "Your dictionary has been updated!"
 msgstr "تم تحديث معجمك!"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:65
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:67
 msgid "Your dictionary is empty"
 msgstr "معجمك فارغ"
 

--- a/packages/i18n/locales/ar.po
+++ b/packages/i18n/locales/ar.po
@@ -50,8 +50,13 @@ msgstr "{0} / {1} بطاقات"
 msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "تم توزيع {0} بطاقة على الأيام {windowDays} القادمة."
 
+#. placeholder {0}: formatNumber(selectedTags.length)
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:214
+msgid "{0} selected"
+msgstr ""
+
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:410
 msgid "{0} tags selected"
 msgstr "{0} علامات محددة"
 
@@ -331,7 +336,7 @@ msgstr "أضف شيئًا لتبدأ!"
 msgid "Add some words to get started!"
 msgstr "أضف بعض الكلمات للبدء!"
 
-#: ../../apps/web/src/components/Autocomplete.tsx:158
+#: ../../apps/web/src/components/Autocomplete.tsx:161
 msgid "Add tag {inputValue}"
 msgstr "أضف علامة {inputValue}"
 
@@ -477,7 +482,7 @@ msgstr "المظهر"
 msgid "Apple sign-in failed. Please try again."
 msgstr "فشل تسجيل الدخول باستخدام Apple. يرجى المحاولة مرة أخرى."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:494
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:570
 msgid "Apply"
 msgstr "تطبيق"
 
@@ -633,7 +638,7 @@ msgstr "بتسجيل الدخول، فإنك توافق على <0>سياسة ا�
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:489
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:565
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
@@ -682,11 +687,11 @@ msgstr "السبب:"
 msgid "Choose file"
 msgstr "اختر ملف"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:545
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:630
 msgid "Clear"
 msgstr "امسح"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:274
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:444
 msgid "Clear all"
 msgstr "مسح الكل"
 
@@ -1283,7 +1288,7 @@ msgstr "تصدير المعجم مع البطاقات سيحفظ تقدم الب
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:73
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:475
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:15
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:80
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:42
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:9
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:19
@@ -1429,7 +1434,7 @@ msgstr "مؤنّث"
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:471
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:13
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:76
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:40
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:7
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:17
@@ -1458,8 +1463,8 @@ msgid "Filter by tags..."
 msgstr "رشّح حسب العلامات..."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:166
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:527
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:435
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:612
 msgid "Filters"
 msgstr "الترشيح"
 
@@ -1600,7 +1605,7 @@ msgstr "صعب"
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:71
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:473
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:14
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:79
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:41
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:8
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:18
@@ -1756,7 +1761,7 @@ msgstr "قيمة غير صالحة. يجب أن تكون إحدى القيم ا�
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:469
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:12
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:75
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:39
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:6
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:16
@@ -1895,7 +1900,7 @@ msgstr "المصدر {0}"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:81
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:161
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:85
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:51
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:52
 msgid "Match all"
@@ -1903,7 +1908,7 @@ msgstr ""
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:82
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:162
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:86
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:88
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:52
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:53
 msgid "Match any"
@@ -1954,7 +1959,7 @@ msgid "Morphology only applies to isms and fi'ls. This section will be hidden if
 msgstr "الصرف ينطبق فقط على الأسماء والأفعال. سيتم إخفاء هذا القسم إذا تم تعيين نوع الكلمة إلى أي شيء آخر."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:52
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:69
 msgid "Most difficult"
 msgstr "الأصعب"
 
@@ -2061,7 +2066,7 @@ msgstr "لم يتم العثور على نتائج"
 msgid "No reviews yet today."
 msgstr "لا توجد مراجعات اليوم بعد."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:389
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:311
 msgid "No tags found"
 msgstr "لم يتم العثور على علامات"
 
@@ -2113,7 +2118,7 @@ msgstr "الأقدم"
 msgid "On"
 msgstr "تشغيل"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:278
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:285
 msgid "Only words that have every one of these tags will be included in the deck."
 msgstr ""
 
@@ -2346,17 +2351,17 @@ msgid "Recent Reviews"
 msgstr "المراجعات الأخيرة"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:50
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
 msgid "Recently added"
 msgstr "المضافة حديثًا"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:54
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:70
 msgid "Recently reviewed"
 msgstr "المراجَعة حديثًا"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:48
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:65
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
 msgid "Recently updated"
 msgstr "المحدّثة حديثًا"
 
@@ -2370,7 +2375,7 @@ msgid "Regular reviews done!"
 msgstr "انتهت المراجعات العادية!"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:46
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:64
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
 msgid "Relevance"
 msgstr "الصلة"
 
@@ -2547,7 +2552,7 @@ msgstr "احفظ"
 msgid "Save 30%"
 msgstr "وفّر ٣٠٪"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:386
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:385
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "حفظ التغييرات"
@@ -2569,7 +2574,7 @@ msgstr "ابحث عن علامة..."
 msgid "Search tag..."
 msgstr "ابحث عن علامة..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:340
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
@@ -2580,7 +2585,7 @@ msgstr "البحث في العلامات..."
 msgid "Search..."
 msgstr "ابحث..."
 
-#: ../../apps/web/src/components/Autocomplete.tsx:111
+#: ../../apps/web/src/components/Autocomplete.tsx:114
 msgid "Searching..."
 msgstr "يبحث..."
 
@@ -2603,7 +2608,7 @@ msgstr "اختر إعرابا"
 msgid "Select Tags"
 msgstr "اختيار العلامات"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:329
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:328
 msgid "Select the types of words that you want to include in the deck."
 msgstr "حدد أنواع الكلمات التي تريد تضمينها في المجموعة."
 
@@ -2711,7 +2716,7 @@ msgid "Something went wrong. Please try again."
 msgstr "حدث خطأ ما. يرجى المحاولة مرة أخرى."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:438
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:514
 msgid "Sort by"
 msgstr "ترتيب حسب"
 
@@ -2806,7 +2811,8 @@ msgstr "نظام"
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:181
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:287
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:210
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:461
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
@@ -3112,7 +3118,7 @@ msgstr "إيقاف هذا يحذف البطاقة العكسية."
 msgid "Type"
 msgstr "الجنس"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:325
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:324
 msgid "Types"
 msgstr "أقسام"
 
@@ -3278,7 +3284,7 @@ msgid "Word not found"
 msgstr "الكلمة غير موجودة"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:400
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:476
 msgid "Word types"
 msgstr "أنواع الكلمات"
 
@@ -3305,15 +3311,15 @@ msgstr "الكلمات المضافة"
 msgid "Words Learned"
 msgstr "الكلمات المتعلّمة"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:328
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:252
 msgid "Words must have every selected tag."
 msgstr ""
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:330
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:254
 msgid "Words need only one of the selected tags."
 msgstr ""
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:283
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:290
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "الكلمات التي تحتوي على أي من هذه العلامات ستُدرج في المجموعة."
 

--- a/packages/i18n/locales/en.po
+++ b/packages/i18n/locales/en.po
@@ -51,7 +51,7 @@ msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "{0} cards have been spread over the next {windowDays} days."
 
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:215
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:239
 msgid "{0} tags selected"
 msgstr "{0} tags selected"
 
@@ -171,7 +171,7 @@ msgstr "{totalHits, plural, one {result} other {results}}"
 
 #. placeholder {0}: formatNumber(totalResults)
 #. placeholder {1}: formatNumber(totalResults)
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:126
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:127
 msgid "{totalResults, plural, one {{0} result} other {{1} results}}"
 msgstr "{totalResults, plural, one {{0} result} other {{1} results}}"
 
@@ -221,7 +221,7 @@ msgstr "7-day average"
 msgid "90 days"
 msgstr "90 days"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:57
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:65
 msgid "A new version is ready to install."
 msgstr "A new version is ready to install."
 
@@ -268,8 +268,8 @@ msgstr "Active Participle"
 msgid "Add a new SQL migration."
 msgstr "Add a new SQL migration."
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:88
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:241
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:92
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:255
 msgid "Add a new word"
 msgstr "Add a new word"
 
@@ -327,7 +327,7 @@ msgstr "Add Plural"
 msgid "Add some to get started!"
 msgstr "Add some to get started!"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:68
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:70
 msgid "Add some words to get started!"
 msgstr "Add some words to get started!"
 
@@ -345,8 +345,8 @@ msgstr "Add tags to your word."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:105
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:72
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:150
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:63
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:151
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:67
 msgid "Add word"
 msgstr "Add word"
 
@@ -446,15 +446,15 @@ msgstr "Any plural forms of the word."
 msgid "Any words that have the same ID will be overwritten."
 msgstr "Any words that have the same ID will be overwritten."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:421
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:427
 msgid "Anything using this key stops working immediately. This can't be undone."
 msgstr "Anything using this key stops working immediately. This can't be undone."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:342
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:348
 msgid "API key revoked"
 msgstr "API key revoked"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:461
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:467
 #: ../../apps/mobile/src/app/(search)/settings.tsx:638
 msgid "API keys"
 msgstr "API keys"
@@ -477,7 +477,7 @@ msgstr "Appearance"
 msgid "Apple sign-in failed. Please try again."
 msgstr "Apple sign-in failed. Please try again."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:426
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:487
 msgid "Apply"
 msgstr "Apply"
 
@@ -521,7 +521,7 @@ msgstr "Arabic word"
 msgid "Are you sure you want to delete this word? It will be removed from your dictionary and its flashcards will be deleted.<0/><1/><2>This action cannot be undone.</2>"
 msgstr "Are you sure you want to delete this word? It will be removed from your dictionary and its flashcards will be deleted.<0/><1/><2>This action cannot be undone.</2>"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:298
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:304
 msgid "Are you sure you want to delete this word? This action cannot be undone."
 msgstr "Are you sure you want to delete this word? This action cannot be undone."
 
@@ -529,7 +529,7 @@ msgstr "Are you sure you want to delete this word? This action cannot be undone.
 msgid "Are you sure you want to delete your dictionary? All your words will be deleted permanently. This action cannot be undone. Please make sure to export your dictionary before deleting it."
 msgstr "Are you sure you want to delete your dictionary? All your words will be deleted permanently. This action cannot be undone. Please make sure to export your dictionary before deleting it."
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:318
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:324
 msgid "Are you sure you want to reset the flashcard for this word? This will reset all spaced repetition progress."
 msgstr "Are you sure you want to reset the flashcard for this word? This will reset all spaced repetition progress."
 
@@ -630,21 +630,21 @@ msgstr "By signing in, you agree to our <0>Privacy Policy</0>"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:691
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:748
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:248
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:437
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:421
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:482
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:97
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:117
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:252
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:324
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:300
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:320
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:432
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:219
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:138
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:305
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:342
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:306
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:326
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:450
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -682,15 +682,15 @@ msgstr "Cause:"
 msgid "Choose file"
 msgstr "Choose file"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:477
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:538
 msgid "Clear"
 msgstr "Clear"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:249
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:273
 msgid "Clear all"
 msgstr "Clear all"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:310
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:368
 msgid "Clear all filters"
 msgstr "Clear all filters"
 
@@ -771,7 +771,7 @@ msgstr "Copied!"
 msgid "Copy"
 msgstr "Copy"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:297
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:302
 msgid "Copy API key"
 msgstr "Copy API key"
 
@@ -779,7 +779,7 @@ msgstr "Copy API key"
 msgid "Copy it now — you won't be able to see it again. Anyone with this key can read and write your dictionary."
 msgstr "Copy it now — you won't be able to see it again. Anyone with this key can read and write your dictionary."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:475
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:481
 msgid "Couldn't load your API keys. Please try again later."
 msgstr "Couldn't load your API keys. Please try again later."
 
@@ -796,18 +796,18 @@ msgstr "Create \"{0}\""
 #~ msgid "Create a deck to organize your flashcard reviews"
 #~ msgstr "Create a deck to organize your flashcard reviews"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:77
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:46
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:103
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:81
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:59
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:121
 msgid "Create a new deck"
 msgstr "Create a new deck"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:81
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:85
 msgid "Create a new deck by choosing filters. The deck will be composed of the cards that match the filters."
 msgstr "Create a new deck by choosing filters. The deck will be composed of the cards that match the filters."
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:472
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:273
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:287
 msgid "Create a reverse card"
 msgstr "Create a reverse card"
 
@@ -837,14 +837,14 @@ msgstr "Create deck"
 #~ msgstr "Create Deck"
 
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:243
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:504
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:510
 msgid "Create key"
 msgstr "Create key"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:512
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:539
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:306
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:313
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:324
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:331
 msgid "Create multiple"
 msgstr "Create multiple"
 
@@ -879,7 +879,7 @@ msgid "Customize how the application looks for you."
 msgstr "Customize how the application looks for you."
 
 #: ../../apps/mobile/src/app/(search)/settings.tsx:844
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:225
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:278
 msgid "Danger Zone"
 msgstr "Danger Zone"
 
@@ -901,20 +901,20 @@ msgstr "days"
 msgid "Debugging"
 msgstr "Debugging"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:59
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:74
 msgid "Deck created"
 msgstr "Deck created"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:95
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:113
 msgid "Deck deleted"
 msgstr "Deck deleted"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:111
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:166
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:129
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:187
 msgid "Deck Name"
 msgstr "Deck Name"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:168
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:182
 msgid "Deck successfully created!"
 msgstr "Deck successfully created!"
 
@@ -922,11 +922,11 @@ msgstr "Deck successfully created!"
 msgid "Deck successfully deleted!"
 msgstr "Deck successfully deleted!"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:164
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:178
 msgid "Deck successfully updated!"
 msgstr "Deck successfully updated!"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:82
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:100
 msgid "Deck updated"
 msgstr "Deck updated"
 
@@ -934,11 +934,11 @@ msgstr "Deck updated"
 #: ../../apps/web/src/components/MobileHeader.tsx:166
 #: ../../apps/web/src/components/DesktopNavigation.tsx:69
 #: ../../apps/web/src/components/DesktopNavigation.tsx:75
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:283
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:292
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:32
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:133
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:198
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:281
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:248
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:334
 msgid "Decks"
 msgstr "Decks"
 
@@ -964,8 +964,8 @@ msgstr "Definition"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/decks/route.lazy.tsx:191
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:80
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:89
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:119
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:302
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:140
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:308
 msgid "Delete"
 msgstr "Delete"
 
@@ -974,7 +974,7 @@ msgstr "Delete"
 msgid "Delete \"{0}\"?"
 msgstr "Delete \"{0}\"?"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:114
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:135
 msgid "Delete \"{name}\"?"
 msgstr "Delete \"{name}\"?"
 
@@ -993,7 +993,7 @@ msgstr "Delete Account"
 msgid "Delete All Data"
 msgstr "Delete All Data"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:243
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:296
 msgid "Delete Deck"
 msgstr "Delete Deck"
 
@@ -1009,7 +1009,7 @@ msgstr "Delete Everything"
 msgid "Delete this word?"
 msgstr "Delete this word?"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:297
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:303
 msgid "Delete word"
 msgstr "Delete word"
 
@@ -1073,12 +1073,12 @@ msgstr "Dismiss"
 msgid "Don't show"
 msgstr "Don't show"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:309
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:315
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:190
 msgid "Done"
 msgstr "Done"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:83
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:91
 msgid "Downloading update"
 msgstr "Downloading update"
 
@@ -1093,8 +1093,8 @@ msgstr "Dual"
 msgid "due"
 msgstr "due"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:118
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:173
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:136
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:194
 msgid "e.g. Essential Vocabulary"
 msgstr "e.g. Essential Vocabulary"
 
@@ -1125,9 +1125,9 @@ msgstr "Edit"
 msgid "Edit {word}"
 msgstr "Edit {word}"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:48
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:158
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:286
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:61
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:179
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:339
 msgid "Edit deck"
 msgstr "Edit deck"
 
@@ -1135,17 +1135,17 @@ msgstr "Edit deck"
 #~ msgid "Edit Deck"
 #~ msgstr "Edit Deck"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:62
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:89
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:377
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:66
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:93
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:391
 msgid "Edit word"
 msgstr "Edit word"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:94
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:98
 msgid "Edit your deck"
 msgstr "Edit your deck"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:98
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:102
 msgid "Edit your deck by choosing filters. The deck will be composed of the cards that match the filters."
 msgstr "Edit your deck by choosing filters. The deck will be composed of the cards that match the filters."
 
@@ -1174,7 +1174,7 @@ msgstr "English → Arabic"
 msgid "English → Arabic, for this word."
 msgstr "English → Arabic, for this word."
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:276
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:290
 msgid "English to Arabic, for this word."
 msgstr "English to Arabic, for this word."
 
@@ -1183,7 +1183,7 @@ msgstr "English to Arabic, for this word."
 msgid "English translation"
 msgstr "English translation"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:210
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:224
 msgid "Enter a deck name"
 msgstr "Enter a deck name"
 
@@ -1234,12 +1234,12 @@ msgstr "Example usages of the word in different contexts."
 msgid "Examples"
 msgstr "Examples"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:384
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:390
 msgid "Expired"
 msgstr "Expired"
 
 #. placeholder {0}: intlFormatDistance(expiresAt, now, { locale: i18n.locale, }).label
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:386
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:392
 msgid "Expires {0}"
 msgstr "Expires {0}"
 
@@ -1278,21 +1278,21 @@ msgstr "Exporting dictionary with flashcards will save your flashcard progress a
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:50
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:17
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:69
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:74
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:136
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:468
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:73
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:475
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:15
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:72
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:42
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:9
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:19
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:39
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:40
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:44
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:45
 msgid "Expression"
 msgstr "Expression"
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:145
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:151
 msgid "Failed to add word"
 msgstr "Failed to add word"
 
@@ -1318,7 +1318,7 @@ msgstr "Failed to autofill"
 msgid "Failed to create API key"
 msgstr "Failed to create API key"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:63
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:78
 msgid "Failed to create deck"
 msgstr "Failed to create deck"
 
@@ -1336,7 +1336,7 @@ msgstr "Failed to delete account"
 msgid "Failed to delete dictionary"
 msgstr "Failed to delete dictionary"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:140
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:146
 msgid "Failed to delete word"
 msgstr "Failed to delete word"
 
@@ -1361,7 +1361,7 @@ msgstr "Failed to generate example"
 msgid "Failed to reschedule backlog"
 msgstr "Failed to reschedule backlog"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:187
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:193
 msgid "Failed to reset flashcard"
 msgstr "Failed to reset flashcard"
 
@@ -1377,11 +1377,11 @@ msgstr "Failed to retrieve data from local database."
 msgid "Failed to retrieve database information."
 msgstr "Failed to retrieve database information."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:344
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:350
 msgid "Failed to revoke API key"
 msgstr "Failed to revoke API key"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:86
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:104
 msgid "Failed to update deck"
 msgstr "Failed to update deck"
 
@@ -1405,7 +1405,7 @@ msgstr "Failed to update settings"
 msgid "Failed to update the word!"
 msgstr "Failed to update the word!"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:123
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:129
 msgid "Failed to update word"
 msgstr "Failed to update word"
 
@@ -1423,18 +1423,18 @@ msgstr "Feminine"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:48
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:13
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:67
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:72
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:90
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:130
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:65
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:464
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:471
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:13
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:70
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:76
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:40
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:7
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:17
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:37
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:38
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:42
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:43
 msgid "Fi'l"
 msgstr "Fi'l"
 
@@ -1457,13 +1457,13 @@ msgstr "Fill in the word, translation, and type first."
 msgid "Filter by tags..."
 msgstr "Filter by tags..."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:146
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:459
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:164
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:264
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:520
 msgid "Filters"
 msgstr "Filters"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:184
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:190
 msgid "Flashcard reset successfully"
 msgstr "Flashcard reset successfully"
 
@@ -1475,8 +1475,8 @@ msgstr "Flashcard settings updated!"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:461
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:224
 #: ../../apps/mobile/src/app/(search)/settings.tsx:673
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:269
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:422
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:283
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:436
 msgid "Flashcards"
 msgstr "Flashcards"
 
@@ -1550,7 +1550,7 @@ msgstr "Get Started"
 #~ msgstr "GitHub"
 
 #: ../../apps/web/src/components/OTPForm.tsx:129
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:353
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:359
 msgid "Go back"
 msgstr "Go back"
 
@@ -1593,19 +1593,19 @@ msgstr "Hard"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:49
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:15
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:68
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:73
 #: ../../apps/web/src/components/features/dictionary/add/VerbMorphologyCardSection.tsx:350
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:101
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:133
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:466
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:71
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:473
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:14
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:71
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:41
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:8
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:18
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:38
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:39
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:43
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:44
 msgid "Harf"
 msgstr "Harf"
 
@@ -1627,7 +1627,7 @@ msgstr "Hidden"
 msgid "Hide details"
 msgstr "Hide details"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:117
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
 msgid "Hide filters"
 msgstr "Hide filters"
 
@@ -1640,9 +1640,9 @@ msgstr "Hint"
 #: ../../apps/web/src/components/MobileHeader.tsx:154
 #: ../../apps/web/src/components/DesktopNavigation.tsx:53
 #: ../../apps/web/src/components/DesktopNavigation.tsx:59
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:272
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:58
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:57
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:281
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:62
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:61
 msgid "Home"
 msgstr "Home"
 
@@ -1750,18 +1750,18 @@ msgstr "Invalid value. Expected one of: {0}"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:47
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/TagBadgesList.tsx:11
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:66
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:71
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:76
 #: ../../apps/web/src/components/features/dictionary/add/CategoryFormSection.tsx:127
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:63
-#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:462
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
+#: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:469
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:12
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:69
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:75
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:39
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:6
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:16
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:36
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:37
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:41
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:42
 msgid "Ism"
 msgstr "Ism"
 
@@ -1775,11 +1775,11 @@ msgstr "Ism"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:516
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:543
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:314
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:332
 msgid "Keep adding words after saving instead of going back to the homepage."
 msgstr "Keep adding words after saving instead of going back to the homepage."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:465
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:471
 msgid "Keys let the Bahar CLI and other tools read and write your dictionary on your behalf."
 msgstr "Keys let the Bahar CLI and other tools read and write your dictionary on your behalf."
 
@@ -1789,7 +1789,7 @@ msgid "Language"
 msgstr "Language"
 
 #. placeholder {0}: intlFormatDistance(lastRequest, now, { locale: i18n.locale, }).label
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:369
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:375
 msgid "Last used {0}"
 msgstr "Last used {0}"
 
@@ -1811,16 +1811,16 @@ msgstr "Light"
 msgid "Loading details..."
 msgstr "Loading details..."
 
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:282
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:284
 msgid "Loading your dictionary..."
 msgstr "Loading your dictionary..."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:87
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:142
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:143
 msgid "Loading..."
 msgstr "Loading..."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:481
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:487
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1835,7 +1835,7 @@ msgstr "Log in to your existing account or sign up for a new one"
 
 #: ../../apps/web/src/components/MobileHeader.tsx:203
 #: ../../apps/web/src/components/DesktopNavigation.tsx:135
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:180
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:187
 msgid "Logout"
 msgstr "Logout"
 
@@ -1897,6 +1897,22 @@ msgstr "Masdar"
 msgid "Masdar {0}"
 msgstr "Masdar {0}"
 
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:81
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:161
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:85
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:51
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:52
+msgid "Match all"
+msgstr "Match all"
+
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:82
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:162
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:86
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:52
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:53
+msgid "Match any"
+msgstr "Match any"
+
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:251
 msgid "Matching tags"
 msgstr "Matching tags"
@@ -1941,8 +1957,8 @@ msgstr "Morphology"
 msgid "Morphology only applies to isms and fi'ls. This section will be hidden if the type of the word is set to anything else."
 msgstr "Morphology only applies to isms and fi'ls. This section will be hidden if the type of the word is set to anything else."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:47
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:61
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:52
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
 msgid "Most difficult"
 msgstr "Most difficult"
 
@@ -1956,7 +1972,7 @@ msgstr "My agent"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/decks/route.lazy.tsx:102
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:168
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:203
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:217
 msgid "Name"
 msgstr "Name"
 
@@ -1968,11 +1984,11 @@ msgstr "Navigation menu"
 msgid "Never"
 msgstr "Never"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:396
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:402
 msgid "Never expires"
 msgstr "Never expires"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:378
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:384
 msgid "Never used"
 msgstr "Never used"
 
@@ -1981,7 +1997,7 @@ msgstr "Never used"
 msgid "New cards scheduled for review each day, in addition to any cards that are already due."
 msgstr "New cards scheduled for review each day, in addition to any cards that are already due."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:253
 msgid "New deck"
 msgstr "New deck"
 
@@ -2040,7 +2056,7 @@ msgid "No overdue cards to reschedule."
 msgstr "No overdue cards to reschedule."
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:839
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:85
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:87
 msgid "No results found"
 msgstr "No results found"
 
@@ -2049,7 +2065,7 @@ msgstr "No results found"
 msgid "No reviews yet today."
 msgstr "No reviews yet today."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:321
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:382
 msgid "No tags found"
 msgstr "No tags found"
 
@@ -2085,7 +2101,7 @@ msgstr "now"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:489
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:94
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:337
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:283
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:297
 msgid "Off"
 msgstr "Off"
 
@@ -2097,9 +2113,18 @@ msgstr "Oldest"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:492
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:97
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:338
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:284
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:298
 msgid "On"
 msgstr "On"
+
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:272
+msgid "Only words that have every one of these tags will be included in the deck."
+msgstr "Only words that have every one of these tags will be included in the deck."
+
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:199
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:257
+msgid "Only words with every one of these tags will be included"
+msgstr "Only words with every one of these tags will be included"
 
 #: ../../apps/mobile/src/app/(search)/stats.tsx:37
 #~ msgid "Open web app"
@@ -2161,7 +2186,7 @@ msgstr "Percentage of mature card reviews not rated \"Again\" over the last 7 da
 msgid "Permanently delete all your data including words, flashcards, and decks."
 msgstr "Permanently delete all your data including words, flashcards, and decks."
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:230
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:283
 msgid "Permanently delete this deck. Your words and flashcards will not be affected."
 msgstr "Permanently delete this deck. Your words and flashcards will not be affected."
 
@@ -2197,7 +2222,7 @@ msgstr "Please sign in again to delete your account"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:223
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/settings/route.lazy.tsx:239
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:134
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:345
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:351
 msgid "Please try again later."
 msgstr "Please try again later."
 
@@ -2295,7 +2320,7 @@ msgstr "Pro"
 #: ../../apps/web/src/components/DesktopNavigation.tsx:91
 #: ../../apps/mobile/src/app/(search)/stats.tsx:31
 #: ../../apps/mobile/src/app/(search)/stats.tsx:272
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:294
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:303
 msgid "Progress"
 msgstr "Progress"
 
@@ -2324,18 +2349,18 @@ msgstr "Receive product updates, tips, and new feature announcements."
 msgid "Recent Reviews"
 msgstr "Recent Reviews"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:45
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:60
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:50
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
 msgid "Recently added"
 msgstr "Recently added"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:49
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:62
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:54
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
 msgid "Recently reviewed"
 msgstr "Recently reviewed"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:43
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:59
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:48
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:65
 msgid "Recently updated"
 msgstr "Recently updated"
 
@@ -2348,8 +2373,8 @@ msgstr "Recently used"
 msgid "Regular reviews done!"
 msgstr "Regular reviews done!"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:41
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:58
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:46
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:64
 msgid "Relevance"
 msgstr "Relevance"
 
@@ -2394,7 +2419,7 @@ msgstr "Reschedule backlog"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:468
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:89
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:322
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:328
 msgid "Reset"
 msgstr "Reset"
 
@@ -2404,7 +2429,7 @@ msgstr "Reset and re-sync"
 
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx:106
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/edit/$wordId.tsx:140
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:317
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:323
 msgid "Reset flashcard"
 msgstr "Reset flashcard"
 
@@ -2449,7 +2474,7 @@ msgstr "Reverse card"
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:128
 #: ../../apps/web/src/components/features/flashcards/FlashcardDrawer/FlashcardDrawer.tsx:328
 #: ../../apps/mobile/src/components/flashcards/FlashcardReview.tsx:86
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:166
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:167
 msgid "Review"
 msgstr "Review"
 
@@ -2485,16 +2510,16 @@ msgstr "Review your Arabic flashcards and grade your understanding with Again, H
 msgid "Reviews"
 msgstr "Reviews"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:410
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:431
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:416
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:437
 msgid "Revoke"
 msgstr "Revoke"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:406
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:412
 msgid "Revoke {label}"
 msgstr "Revoke {label}"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:417
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:423
 msgid "Revoke this API key?"
 msgstr "Revoke this API key?"
 
@@ -2516,9 +2541,9 @@ msgstr "Root Letters"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:558
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:322
 #: ../../apps/web/src/components/features/settings/AdminSettingsCardSection.tsx:146
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:179
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:262
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:334
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:229
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:315
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:352
 msgid "Save"
 msgstr "Save"
 
@@ -2526,8 +2551,8 @@ msgstr "Save"
 msgid "Save 30%"
 msgstr "Save 30%"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:334
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:442
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:380
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "Save changes"
 
@@ -2548,14 +2573,14 @@ msgstr "Search for a tag..."
 msgid "Search tag..."
 msgstr "Search tag..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:272
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:333
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
 msgstr "Search tags..."
 
 #: ../../apps/web/src/components/search/SearchInput.tsx:63
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:128
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:135
 msgid "Search..."
 msgstr "Search..."
 
@@ -2582,7 +2607,7 @@ msgstr "Select inflection"
 msgid "Select Tags"
 msgstr "Select Tags"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:323
 msgid "Select the types of words that you want to include in the deck."
 msgstr "Select the types of words that you want to include in the deck."
 
@@ -2592,8 +2617,8 @@ msgstr "Select the types of words that you want to include in the deck."
 msgid "Select type"
 msgstr "Select type"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:132
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:187
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:150
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:208
 msgid "Select which types of words to include"
 msgstr "Select which types of words to include"
 
@@ -2614,7 +2639,7 @@ msgstr "Separate letters with spaces or commas"
 #: ../../apps/web/src/components/DesktopNavigation.tsx:123
 #: ../../apps/mobile/src/app/(search)/settings.tsx:254
 #: ../../apps/mobile/src/app/(search)/settings.tsx:556
-#: ../../apps/mobile/src/app/(search)/_layout.tsx:305
+#: ../../apps/mobile/src/app/(search)/_layout.tsx:314
 msgid "Settings"
 msgstr "Settings"
 
@@ -2646,7 +2671,7 @@ msgstr "Show details"
 #~ msgid "Show English to Arabic flashcards."
 #~ msgstr "Show English to Arabic flashcards."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:117
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
 msgid "Show filters"
 msgstr "Show filters"
 
@@ -2678,7 +2703,7 @@ msgid "Some dictionary entries couldn't be loaded"
 msgstr "Some dictionary entries couldn't be loaded"
 
 #: ../../apps/web/src/routes/cli-auth/route.lazy.tsx:51
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:292
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:294
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
@@ -2689,8 +2714,8 @@ msgstr "Something went wrong"
 msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:246
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:370
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:431
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -2782,15 +2807,15 @@ msgid "System"
 msgstr "System"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:328
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:155
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:173
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:229
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:262
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:286
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:151
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:206
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:259
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:412
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:273
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:426
 msgid "Tags"
 msgstr "Tags"
 
@@ -2886,7 +2911,7 @@ msgstr "There was an error adding your word. Please try again."
 #~ msgid "There was an error clearing your backlog."
 #~ msgstr "There was an error clearing your backlog."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:180
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:194
 msgid "There was an error creating the deck"
 msgstr "There was an error creating the deck"
 
@@ -2919,7 +2944,7 @@ msgstr "There was an error rescheduling your backlog."
 #~ msgid "There was an error syncing your data. Your local data is still available."
 #~ msgstr "There was an error syncing your data. Your local data is still available."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:176
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:190
 msgid "There was an error updating the deck"
 msgstr "There was an error updating the deck"
 
@@ -2949,7 +2974,7 @@ msgid "There's a temporary issue loading your account. Please try reloading the 
 msgstr "There's a temporary issue loading your account. Please try reloading the page."
 
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:85
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:115
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:136
 msgid "This cannot be undone. Your words and flashcards will not be affected."
 msgstr "This cannot be undone. Your words and flashcards will not be affected."
 
@@ -2978,7 +3003,7 @@ msgstr "This field is required."
 msgid "This is case insensitive."
 msgstr "This is case insensitive."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:217
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:231
 msgid "This is the name of your deck."
 msgstr "This is the name of your deck."
 
@@ -3072,7 +3097,7 @@ msgstr "Triptote"
 #~ msgstr "Troubleshooting"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:842
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:88
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:90
 msgid "Try a different search term"
 msgstr "Try a different search term"
 
@@ -3086,7 +3111,7 @@ msgstr "Turning this off deletes the reverse flashcard."
 msgid "Type"
 msgstr "Type"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:273
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:319
 msgid "Types"
 msgstr "Types"
 
@@ -3113,7 +3138,7 @@ msgstr "Unknown error."
 msgid "Unlock Insights"
 msgstr "Unlock Insights"
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:356
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:362
 msgid "Unnamed key"
 msgstr "Unnamed key"
 
@@ -3122,11 +3147,11 @@ msgstr "Unnamed key"
 msgid "Unsubscribed from marketing emails"
 msgstr "Unsubscribed from marketing emails"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:67
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:75
 msgid "Update"
 msgstr "Update"
 
-#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:53
+#: ../../apps/mobile/src/components/updates/UpdateBanner.tsx:61
 msgid "Update available"
 msgstr "Update available"
 
@@ -3239,29 +3264,29 @@ msgstr "Welcome to Bahar!"
 msgid "Word"
 msgstr "Word"
 
-#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:136
+#: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:142
 msgid "Word added successfully"
 msgstr "Word added successfully"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:136
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:142
 msgid "Word deleted successfully"
 msgstr "Word deleted successfully"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:350
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:356
 msgid "Word not found"
 msgstr "Word not found"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:203
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:332
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:393
 msgid "Word types"
 msgstr "Word types"
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:129
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:184
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:147
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:205
 msgid "Word Types"
 msgstr "Word Types"
 
-#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:119
+#: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:125
 msgid "Word updated successfully"
 msgstr "Word updated successfully"
 
@@ -3279,7 +3304,17 @@ msgstr "Words Added"
 msgid "Words Learned"
 msgstr "Words Learned"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:210
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:322
+msgid "Words must have every selected tag."
+msgstr "Words must have every selected tag."
+
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:212
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:324
+msgid "Words need only one of the selected tags."
+msgstr "Words need only one of the selected tags."
+
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "Words that have any of these tags will be included in the deck."
 
@@ -3292,8 +3327,8 @@ msgstr "Words that have graduated from the learning phase into review."
 msgid "Words that have the opposite meaning."
 msgstr "Words that have the opposite meaning."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:154
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:209
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:261
 msgid "Words with any of these tags will be included"
 msgstr "Words with any of these tags will be included"
 
@@ -3319,7 +3354,7 @@ msgstr "You can close this tab once your terminal shows you're signed in."
 msgid "You do not have access to upload schema migrations."
 msgstr "You do not have access to upload schema migrations."
 
-#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:487
+#: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:493
 msgid "You don't have any API keys yet. Signing in with `bahar login` creates one for you."
 msgstr "You don't have any API keys yet. Signing in with `bahar login` creates one for you."
 
@@ -3374,16 +3409,16 @@ msgstr "Your Arabic learning companion"
 #~ msgid "Your data has been re-synced from the server."
 #~ msgstr "Your data has been re-synced from the server."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:181
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:195
 msgid "Your deck was not created. Please try again."
 msgstr "Your deck was not created. Please try again."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:177
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:191
 msgid "Your deck was not updated. Please try again."
 msgstr "Your deck was not updated. Please try again."
 
 #: ../../apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx:63
-#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:121
+#: ../../apps/mobile/src/app/(search)/(home)/index.tsx:122
 msgid "Your Dictionary"
 msgstr "Your Dictionary"
 
@@ -3399,7 +3434,7 @@ msgstr "Your dictionary has been downloaded."
 msgid "Your dictionary has been updated!"
 msgstr "Your dictionary has been updated!"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:65
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:67
 msgid "Your dictionary is empty"
 msgstr "Your dictionary is empty"
 

--- a/packages/i18n/locales/en.po
+++ b/packages/i18n/locales/en.po
@@ -50,8 +50,13 @@ msgstr "{0} / {1} cards"
 msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "{0} cards have been spread over the next {windowDays} days."
 
+#. placeholder {0}: formatNumber(selectedTags.length)
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:214
+msgid "{0} selected"
+msgstr "{0} selected"
+
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:410
 msgid "{0} tags selected"
 msgstr "{0} tags selected"
 
@@ -331,7 +336,7 @@ msgstr "Add some to get started!"
 msgid "Add some words to get started!"
 msgstr "Add some words to get started!"
 
-#: ../../apps/web/src/components/Autocomplete.tsx:158
+#: ../../apps/web/src/components/Autocomplete.tsx:161
 msgid "Add tag {inputValue}"
 msgstr "Add tag {inputValue}"
 
@@ -477,7 +482,7 @@ msgstr "Appearance"
 msgid "Apple sign-in failed. Please try again."
 msgstr "Apple sign-in failed. Please try again."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:494
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:570
 msgid "Apply"
 msgstr "Apply"
 
@@ -633,7 +638,7 @@ msgstr "By signing in, you agree to our <0>Privacy Policy</0>"
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:489
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:565
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
@@ -682,11 +687,11 @@ msgstr "Cause:"
 msgid "Choose file"
 msgstr "Choose file"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:545
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:630
 msgid "Clear"
 msgstr "Clear"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:274
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:444
 msgid "Clear all"
 msgstr "Clear all"
 
@@ -1283,7 +1288,7 @@ msgstr "Exporting dictionary with flashcards will save your flashcard progress a
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:73
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:475
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:15
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:80
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:42
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:9
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:19
@@ -1429,7 +1434,7 @@ msgstr "Feminine"
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:69
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:471
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:13
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:76
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:78
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:40
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:7
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:17
@@ -1458,8 +1463,8 @@ msgid "Filter by tags..."
 msgstr "Filter by tags..."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:166
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:527
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:435
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:612
 msgid "Filters"
 msgstr "Filters"
 
@@ -1600,7 +1605,7 @@ msgstr "Hard"
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:71
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:473
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:14
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:79
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:41
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:8
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:18
@@ -1756,7 +1761,7 @@ msgstr "Invalid value. Expected one of: {0}"
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:67
 #: ../../apps/mobile/src/components/flashcards/FlashcardCard.tsx:469
 #: ../../apps/mobile/src/components/flashcards/card/PropertiesRow.tsx:12
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:75
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:77
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:39
 #: ../../apps/mobile/src/components/dictionary/form/constants.ts:6
 #: ../../apps/mobile/src/components/decks/DeckCard.tsx:16
@@ -1899,7 +1904,7 @@ msgstr "Masdar {0}"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:81
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:161
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:85
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:51
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:52
 msgid "Match all"
@@ -1907,7 +1912,7 @@ msgstr "Match all"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:82
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:162
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:86
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:88
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:52
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:53
 msgid "Match any"
@@ -1958,7 +1963,7 @@ msgid "Morphology only applies to isms and fi'ls. This section will be hidden if
 msgstr "Morphology only applies to isms and fi'ls. This section will be hidden if the type of the word is set to anything else."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:52
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:69
 msgid "Most difficult"
 msgstr "Most difficult"
 
@@ -2065,7 +2070,7 @@ msgstr "No results found"
 msgid "No reviews yet today."
 msgstr "No reviews yet today."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:389
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:311
 msgid "No tags found"
 msgstr "No tags found"
 
@@ -2117,7 +2122,7 @@ msgstr "Oldest"
 msgid "On"
 msgstr "On"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:278
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:285
 msgid "Only words that have every one of these tags will be included in the deck."
 msgstr "Only words that have every one of these tags will be included in the deck."
 
@@ -2350,17 +2355,17 @@ msgid "Recent Reviews"
 msgstr "Recent Reviews"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:50
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
 msgid "Recently added"
 msgstr "Recently added"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:54
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:68
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:70
 msgid "Recently reviewed"
 msgstr "Recently reviewed"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:48
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:65
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:67
 msgid "Recently updated"
 msgstr "Recently updated"
 
@@ -2374,7 +2379,7 @@ msgid "Regular reviews done!"
 msgstr "Regular reviews done!"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:46
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:64
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:66
 msgid "Relevance"
 msgstr "Relevance"
 
@@ -2551,7 +2556,7 @@ msgstr "Save"
 msgid "Save 30%"
 msgstr "Save 30%"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:386
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:385
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "Save changes"
@@ -2573,7 +2578,7 @@ msgstr "Search for a tag..."
 msgid "Search tag..."
 msgstr "Search tag..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:340
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
@@ -2584,7 +2589,7 @@ msgstr "Search tags..."
 msgid "Search..."
 msgstr "Search..."
 
-#: ../../apps/web/src/components/Autocomplete.tsx:111
+#: ../../apps/web/src/components/Autocomplete.tsx:114
 msgid "Searching..."
 msgstr "Searching..."
 
@@ -2607,7 +2612,7 @@ msgstr "Select inflection"
 msgid "Select Tags"
 msgstr "Select Tags"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:329
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:328
 msgid "Select the types of words that you want to include in the deck."
 msgstr "Select the types of words that you want to include in the deck."
 
@@ -2715,7 +2720,7 @@ msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:438
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:514
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -2810,7 +2815,8 @@ msgstr "System"
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:181
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:287
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:210
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:461
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
@@ -3116,7 +3122,7 @@ msgstr "Turning this off deletes the reverse flashcard."
 msgid "Type"
 msgstr "Type"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:325
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:324
 msgid "Types"
 msgstr "Types"
 
@@ -3282,7 +3288,7 @@ msgid "Word not found"
 msgstr "Word not found"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:400
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:476
 msgid "Word types"
 msgstr "Word types"
 
@@ -3309,15 +3315,15 @@ msgstr "Words Added"
 msgid "Words Learned"
 msgstr "Words Learned"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:328
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:252
 msgid "Words must have every selected tag."
 msgstr "Words must have every selected tag."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:330
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:254
 msgid "Words need only one of the selected tags."
 msgstr "Words need only one of the selected tags."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:283
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:290
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "Words that have any of these tags will be included in the deck."
 

--- a/packages/i18n/locales/en.po
+++ b/packages/i18n/locales/en.po
@@ -51,7 +51,7 @@ msgid "{0} cards have been spread over the next {windowDays} days."
 msgstr "{0} cards have been spread over the next {windowDays} days."
 
 #. placeholder {0}: formatNumber(draftTags.length)
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:239
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:240
 msgid "{0} tags selected"
 msgstr "{0} tags selected"
 
@@ -323,7 +323,7 @@ msgstr "Add plural"
 msgid "Add Plural"
 msgstr "Add Plural"
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:862
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:874
 msgid "Add some to get started!"
 msgstr "Add some to get started!"
 
@@ -477,7 +477,7 @@ msgstr "Appearance"
 msgid "Apple sign-in failed. Please try again."
 msgstr "Apple sign-in failed. Please try again."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:487
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:494
 msgid "Apply"
 msgstr "Apply"
 
@@ -633,14 +633,14 @@ msgstr "By signing in, you agree to our <0>Privacy Policy</0>"
 #: ../../apps/web/src/components/features/settings/ApiKeysCardSection.tsx:443
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:129
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:308
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:482
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:489
 #: ../../apps/mobile/src/app/(search)/settings.tsx:435
 #: ../../apps/mobile/src/app/(search)/settings.tsx:472
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:87
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:97
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:219
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:221
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:138
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:305
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:307
 #: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:342
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:306
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:326
@@ -682,11 +682,11 @@ msgstr "Cause:"
 msgid "Choose file"
 msgstr "Choose file"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:538
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:545
 msgid "Clear"
 msgstr "Clear"
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:273
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:274
 msgid "Clear all"
 msgstr "Clear all"
 
@@ -879,7 +879,7 @@ msgid "Customize how the application looks for you."
 msgstr "Customize how the application looks for you."
 
 #: ../../apps/mobile/src/app/(search)/settings.tsx:844
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:278
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:280
 msgid "Danger Zone"
 msgstr "Danger Zone"
 
@@ -937,8 +937,8 @@ msgstr "Deck updated"
 #: ../../apps/mobile/src/app/(search)/_layout.tsx:292
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:32
 #: ../../apps/mobile/src/app/(search)/decks/index.tsx:133
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:248
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:334
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:250
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:336
 msgid "Decks"
 msgstr "Decks"
 
@@ -993,7 +993,7 @@ msgstr "Delete Account"
 msgid "Delete All Data"
 msgstr "Delete All Data"
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:296
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:298
 msgid "Delete Deck"
 msgstr "Delete Deck"
 
@@ -1127,7 +1127,7 @@ msgstr "Edit {word}"
 
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:61
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:179
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:339
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:341
 msgid "Edit deck"
 msgstr "Edit deck"
 
@@ -1457,9 +1457,9 @@ msgstr "Fill in the word, translation, and type first."
 msgid "Filter by tags..."
 msgstr "Filter by tags..."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:164
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:264
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:520
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:166
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:265
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:527
 msgid "Filters"
 msgstr "Filters"
 
@@ -1627,7 +1627,7 @@ msgstr "Hidden"
 msgid "Hide details"
 msgstr "Hide details"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:137
 msgid "Hide filters"
 msgstr "Hide filters"
 
@@ -1997,7 +1997,7 @@ msgstr "Never used"
 msgid "New cards scheduled for review each day, in addition to any cards that are already due."
 msgstr "New cards scheduled for review each day, in addition to any cards that are already due."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:253
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:255
 msgid "New deck"
 msgstr "New deck"
 
@@ -2055,7 +2055,7 @@ msgstr "No file chosen"
 msgid "No overdue cards to reschedule."
 msgstr "No overdue cards to reschedule."
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:839
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:847
 #: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:87
 msgid "No results found"
 msgstr "No results found"
@@ -2065,7 +2065,7 @@ msgstr "No results found"
 msgid "No reviews yet today."
 msgstr "No reviews yet today."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:382
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:389
 msgid "No tags found"
 msgstr "No tags found"
 
@@ -2117,12 +2117,12 @@ msgstr "Oldest"
 msgid "On"
 msgstr "On"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:272
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:278
 msgid "Only words that have every one of these tags will be included in the deck."
 msgstr "Only words that have every one of these tags will be included in the deck."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:199
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:257
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:201
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:259
 msgid "Only words with every one of these tags will be included"
 msgstr "Only words with every one of these tags will be included"
 
@@ -2186,7 +2186,7 @@ msgstr "Percentage of mature card reviews not rated \"Again\" over the last 7 da
 msgid "Permanently delete all your data including words, flashcards, and decks."
 msgstr "Permanently delete all your data including words, flashcards, and decks."
 
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:283
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:285
 msgid "Permanently delete this deck. Your words and flashcards will not be affected."
 msgstr "Permanently delete this deck. Your words and flashcards will not be affected."
 
@@ -2541,8 +2541,8 @@ msgstr "Root Letters"
 #: ../../apps/web/src/routes/_authorized-layout/_app-layout/dictionary/add/route.lazy.tsx:558
 #: ../../apps/web/src/components/features/settings/FlashcardSettingsCardSection.tsx:322
 #: ../../apps/web/src/components/features/settings/AdminSettingsCardSection.tsx:146
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:229
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:315
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:231
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:317
 #: ../../apps/mobile/src/app/(search)/(home)/add-word.tsx:352
 msgid "Save"
 msgstr "Save"
@@ -2551,7 +2551,7 @@ msgstr "Save"
 msgid "Save 30%"
 msgstr "Save 30%"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:380
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:386
 #: ../../apps/mobile/src/app/(search)/(home)/edit-word/[id].tsx:460
 msgid "Save changes"
 msgstr "Save changes"
@@ -2573,7 +2573,7 @@ msgstr "Search for a tag..."
 msgid "Search tag..."
 msgstr "Search tag..."
 
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:333
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:340
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:105
 #: ../../apps/mobile/src/components/dictionary/form/TagsInput.tsx:217
 msgid "Search tags..."
@@ -2607,7 +2607,7 @@ msgstr "Select inflection"
 msgid "Select Tags"
 msgstr "Select Tags"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:323
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:329
 msgid "Select the types of words that you want to include in the deck."
 msgstr "Select the types of words that you want to include in the deck."
 
@@ -2671,7 +2671,7 @@ msgstr "Show details"
 #~ msgid "Show English to Arabic flashcards."
 #~ msgstr "Show English to Arabic flashcards."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:135
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:137
 msgid "Show filters"
 msgstr "Show filters"
 
@@ -2715,7 +2715,7 @@ msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:304
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:431
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:438
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -2807,10 +2807,10 @@ msgid "System"
 msgstr "System"
 
 #: ../../apps/web/src/components/search/InfiniteScroll.tsx:328
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:173
+#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:181
 #: ../../apps/web/src/components/features/dictionary/add/TagsFormSection.tsx:44
 #: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:243
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:286
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:287
 #: ../../apps/mobile/src/components/dictionary/DictionaryEntryCard.tsx:306
 #: ../../apps/mobile/src/app/(search)/decks/create.tsx:169
 #: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:227
@@ -3096,10 +3096,15 @@ msgstr "Triptote"
 #~ msgid "Troubleshooting"
 #~ msgstr "Troubleshooting"
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:842
-#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:90
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:851
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:91
 msgid "Try a different search term"
 msgstr "Try a different search term"
+
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:853
+#: ../../apps/mobile/src/components/dictionary/DictionaryList.tsx:93
+msgid "Try adjusting your filters"
+msgstr "Try adjusting your filters"
 
 #: ../../apps/web/src/components/features/flashcards/ReverseToggle.tsx:104
 #: ../../apps/mobile/src/components/dictionary/ReviewHistory.tsx:346
@@ -3111,7 +3116,7 @@ msgstr "Turning this off deletes the reverse flashcard."
 msgid "Type"
 msgstr "Type"
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:319
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:325
 msgid "Types"
 msgstr "Types"
 
@@ -3277,7 +3282,7 @@ msgid "Word not found"
 msgstr "Word not found"
 
 #: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:261
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:393
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:400
 msgid "Word types"
 msgstr "Word types"
 
@@ -3304,17 +3309,15 @@ msgstr "Words Added"
 msgid "Words Learned"
 msgstr "Words Learned"
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:210
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:322
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:328
 msgid "Words must have every selected tag."
 msgstr "Words must have every selected tag."
 
-#: ../../apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx:212
-#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:324
+#: ../../apps/mobile/src/components/dictionary/DictionaryFilters.tsx:330
 msgid "Words need only one of the selected tags."
 msgstr "Words need only one of the selected tags."
 
-#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:277
+#: ../../apps/web/src/components/features/decks/DeckDialogContent.tsx:283
 msgid "Words that have any of these tags will be included in the deck."
 msgstr "Words that have any of these tags will be included in the deck."
 
@@ -3327,8 +3330,8 @@ msgstr "Words that have graduated from the learning phase into review."
 msgid "Words that have the opposite meaning."
 msgstr "Words that have the opposite meaning."
 
-#: ../../apps/mobile/src/app/(search)/decks/create.tsx:203
-#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:261
+#: ../../apps/mobile/src/app/(search)/decks/create.tsx:205
+#: ../../apps/mobile/src/app/(search)/decks/edit/[id].tsx:263
 msgid "Words with any of these tags will be included"
 msgstr "Words with any of these tags will be included"
 
@@ -3377,7 +3380,7 @@ msgstr "You have no decks yet."
 msgid "You have no overdue cards to reschedule."
 msgstr "You have no overdue cards to reschedule."
 
-#: ../../apps/web/src/components/search/InfiniteScroll.tsx:859
+#: ../../apps/web/src/components/search/InfiniteScroll.tsx:871
 msgid "You have no words in your dictionary yet."
 msgstr "You have no words in your dictionary yet."
 


### PR DESCRIPTION
## Problem

Tags in this app are hierarchical in practice — source → book → chapter — so users end up with sets of sibling tags at the same level. Selecting two siblings on the home screen always returns zero results, because dictionary search combines tags with AND and no single entry carries both. "Show me both surahs together" is a reasonable thing to want and there was no way to ask for it.

While implementing this I found the two surfaces already disagreed, which changes the shape of the fix:

- **Dictionary search** (`apps/web/src/hooks/search/useSearch.ts`, `apps/mobile/src/hooks/useSearch.ts`) uses Orama `tags: { containsAll }` — **AND**.
- **Deck and flashcard queries** (`packages/db-operations/src/operations/decks.ts`, `flashcards.ts`) use `jt.value IN (...)`, which matches an entry carrying *any one* of the tags — **OR**. This is deliberate and was already pinned by a test named `matches an entry that has ANY of several specified tags (OR)`.

So the same two tags return 0 on the home screen and a union in a deck built from them.

## What this changes

Adds `tagMode: "all" | "any"` to `DeckFilters` and to the web search params, surfaced as a **Match all / Match any** control on:

- the dictionary filters panel (web + mobile)
- the deck create and edit forms (web + mobile)

The control sits above the tag picker, so the picker stays adjacent to the tag pills it produces — putting the mode between them makes it ambiguous which one it applies to. Helper text below the control states what the active mode does. There are no result-count previews, so that sentence is the only thing conveying the semantics, which is why it's always visible rather than shown only for the non-default.

## Why the default is per-surface, not global

An absent `tagMode` resolves to whatever that surface already did:

| Surface | Absent `tagMode` | Rationale |
| --- | --- | --- |
| Dictionary search | `"all"` | Matches today's `containsAll`. A shared or bookmarked URL without the param filters as it always has. |
| Deck / flashcard queries | `"any"` | Matches today's `IN (...)`. Defaulting to `"all"` would silently shrink every existing multi-tag deck. |

This is the one genuinely surprising decision in the PR, so to be explicit: **whether decks should have been AND all along is not decided here.** Making them uniformly `"all"` would change what existing decks contain and needs a migration plus a heads-up to affected users. That's a separate call. This change leaves every existing deck byte-identical in behaviour and only alters things when a user explicitly picks a mode.

Deck *edit* forms open on `deck.filters?.tagMode ?? "any"` so the form shows what the deck has actually been doing. Deck *create* starts on `"all"`, which is what people expect a multi-tag deck to mean.

## Query layer

The tag subquery moved into a shared `buildTagCondition` helper (`packages/db-operations/src/utils.ts`) so the two call sites can't drift.

The existing non-correlated form is preserved — the comments there flag it as load-bearing, since the correlated `EXISTS (json_each(...))` version re-runs `json_each` per candidate row and effectively hangs the single WASM SQLite connection on decks matching many rows. `"all"` adds `GROUP BY de_t.id HAVING COUNT(DISTINCT jt.value) = N` without reintroducing correlation. `COUNT(DISTINCT ...)` rather than `COUNT(*)` so an entry that repeats a tag in its JSON array still has to carry every filter tag, and the caller's tags are de-duplicated so a repeated filter tag can't push `N` past what any entry could reach.

## Testing

- `packages/db-operations`: 160 pass. The 98 pre-existing deck/flashcard tests pass unchanged, which is the evidence the refactor is behaviour-preserving.
- New coverage for `"all"`: requires every tag, tolerates extra tags on the entry, returns nothing for sibling tags no entry shares, ignores a repeated filter tag, and explicit `"any"` still ORs. Plus a test asserting an absent `tagMode` still behaves as OR, guarding the backwards-compatibility promise above.
- Replaced two duplicated tag-filter tests (the same two assertions appeared twice in `decks.test.ts`) with the new cases.
- `apps/mobile`: 14 pass. `tsc --noEmit` clean on `apps/web`, `apps/mobile`, `packages/db-operations`, `packages/drizzle-user-db-schemas`.

Not verified by running the apps — worth a manual pass on the filter panels before merge.

## Needs a human before merge

**Arabic strings are untranslated.** Six new message IDs are in `en.po` with empty `ar.po` entries. Machine-translating these is a bad idea: «مطابقة الكل» / «مطابقة أي» is clumsy, and the all/any distinction is as subtle in Arabic as it is in English. The outcome-phrased helper text ("Words must have every selected tag") should translate more cleanly than the operator-phrased labels, but both need a native pass.

## Follow-ups deliberately not in this PR

- Deciding whether deck tag matching should become uniformly AND, and migrating if so.
- Mobile persists filters to `AsyncStorage` with `getOnInit: true`, so `tagMode` survives app restarts like the other filters. `activeFilterCountAtom` counts a non-default mode so it shows in the filter badge rather than silently narrowing results weeks later — but there's no chip on the collapsed filter row naming the active mode, which would make it visible without opening the modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Match all” and “Match any” tag filtering for dictionary searches and deck creation/editing.
  - Added a dedicated tag picker with search, selection counts, and clearer filter guidance.
  - Tag matching preferences are preserved and applied consistently across web and mobile.

- **Bug Fixes**
  - Improved empty-result messages for searches using tags or other filters.
  - Fixed autocomplete menus appearing behind dialog controls.

- **Localization**
  - Added and updated translations for tag matching and filter guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->