### PR TITLE
fix(mobile): drop the nonexistent hovered flag from the button callback

### DIFF
--- a/apps/mobile/src/components/ui/button.tsx
+++ b/apps/mobile/src/components/ui/button.tsx
@@ -106,8 +106,12 @@ export const Button: FC<ButtonProps> = ({
           <Text
             className={cn(textVariants({ variant, className }), "text-center")}
           >
+            {/* react-native's PressableStateCallbackType is `{ pressed }` and
+                nothing else. `hovered` belongs to react-native-web's version of
+                the type; if the compiler asks for it, node_modules is resolving
+                that one. This line has been flipped twice on that basis. */}
             {typeof children === "function"
-              ? children({ pressed: false, hovered: false })
+              ? children({ pressed: false })
               : children}
           </Text>
         )}


### PR DESCRIPTION
`apps/mobile/src/components/ui/button.tsx` doesn't compile on `main`:

```
src/components/ui/button.tsx(110,44): error TS2345: Object literal may only
specify known properties, and 'hovered' does not exist in type
'PressableStateCallbackType'
```

The shared `Button` renders a function child with a synthetic press state. react-native 0.81.5 declares that state as `{ readonly pressed: boolean }` and nothing else, so the extra `hovered: false` is rejected. Verified against the declaration the app actually resolves — `react-native/Libraries/Components/Pressable/Pressable.d.ts`, reached through the `types` export condition.

## Why it keeps coming back

This is the second removal. `346850c` took the flag out; `8721b73` put it back, with a commit message stating the opposite — that the type now *requires* `hovered`.

Both authors were reading a real compiler error. react-native-web ships its own `PressableStateCallbackType` that does include `hovered` (and `focused`), and `react-native-web` is in the mobile dependency tree. A node_modules state that resolves that declaration produces the inverse error, at which point adding the flag looks like the fix. So the line flips, and whoever installs cleanly next flips it back.

Added a comment on the line naming which surface is authoritative, so the next person who sees the inverse error knows to suspect their install rather than the code.

## Why nothing caught it

- CI (`.github/workflows/test.yml`) runs `pnpm run test` and nothing else.
- `turbo type-check` finds a `type-check` script in `apps/marketing` only — one workspace out of fifteen. `apps/api` and `apps/cli` have the script under a different name (`typecheck`), so turbo doesn't see them either.
- `apps/web` is covered by accident: its `build` script runs `tsc` first, so the Cloudflare Pages check fails on a web type error. `apps/mobile` has no equivalent.

Not addressed here — leaving the CI gap as a separate decision.

## Testing

`tsc --noEmit` is clean across every workspace with this applied: web, mobile, api, cli, marketing, and all nine packages. Mobile jest suite passes (58 tests, 5 suites). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button behavior by removing unsupported hover state data from button content callbacks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->