### PR TITLE
fix(web): move Select onto the filters row on narrow screens

### DIFF
--- a/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
+++ b/apps/web/src/components/features/dictionary/filters/DictionaryFilters.tsx
@@ -26,6 +26,7 @@ import {
   Lock,
   SlidersHorizontal,
 } from "lucide-react";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { TagsFilter } from "@/components/features/dictionary/filters/TagsFilter";
 import { TagPill } from "@/components/TagsCombobox";
@@ -83,7 +84,15 @@ const useTagModeLabels = (): Record<TagMode, string> => {
   };
 };
 
-export const DictionaryFilters = () => {
+/**
+ * `trailingAction` shares the filters toggle's row so callers can put an action
+ * beside it instead of spending another row on it.
+ */
+export const DictionaryFilters = ({
+  trailingAction,
+}: {
+  trailingAction?: ReactNode;
+}) => {
   const navigate = useNavigate();
   const dir = useDir();
   const { formatNumber } = useFormatNumber();
@@ -128,26 +137,34 @@ export const DictionaryFilters = () => {
 
   return (
     <div className="flex flex-col gap-3">
-      <Button
-        className="h-9 w-max gap-2 text-muted-foreground hover:text-foreground"
-        onClick={() => setIsExpanded(!isExpanded)}
-        size="sm"
-        variant="ghost"
-      >
-        {isExpanded ? <Trans>Hide filters</Trans> : <Trans>Show filters</Trans>}
-
-        {hasActiveFilters && (
-          <span className="rounded-full bg-primary px-1.5 py-0.5 text-primary-foreground text-xs">
-            {formatNumber(activeFilterCount)}
-          </span>
-        )}
-        <ChevronDown
-          className={cn(
-            "h-4 w-4 transition-transform duration-200",
-            isExpanded && "rotate-180"
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          className="h-9 w-max gap-2 text-muted-foreground hover:text-foreground"
+          onClick={() => setIsExpanded(!isExpanded)}
+          size="sm"
+          variant="ghost"
+        >
+          {isExpanded ? (
+            <Trans>Hide filters</Trans>
+          ) : (
+            <Trans>Show filters</Trans>
           )}
-        />
-      </Button>
+
+          {hasActiveFilters && (
+            <span className="rounded-full bg-primary px-1.5 py-0.5 text-primary-foreground text-xs">
+              {formatNumber(activeFilterCount)}
+            </span>
+          )}
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 transition-transform duration-200",
+              isExpanded && "rotate-180"
+            )}
+          />
+        </Button>
+
+        {trailingAction}
+      </div>
 
       <div
         className={cn(

--- a/apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx
+++ b/apps/web/src/routes/_authorized-layout/_search-layout/index.lazy.tsx
@@ -28,13 +28,36 @@ import { useSearch } from "@/hooks/search/useSearch";
 import { useFormatNumber } from "@/hooks/useFormatNumber";
 import { flashcardsTable } from "@/lib/db/operations";
 
+/**
+ * Rendered twice with complementary visibility classes: it sits with the other
+ * actions from `sm` up, and drops onto the filters toggle's row below that,
+ * where three buttons no longer fit on one line.
+ */
+const SelectionModeButton = ({ className }: { className?: string }) => {
+  const { selectionMode, enterSelectionMode } = useBulkSelection();
+
+  return (
+    <Button
+      className={cn("h-9 px-3", className)}
+      disabled={selectionMode}
+      onClick={enterSelectionMode}
+      size="sm"
+      variant="outline"
+    >
+      <ListChecks className="h-4 w-4 ltr:mr-1.5 rtl:ml-1.5" />
+      <span className="text-sm">
+        <Trans>Select</Trans>
+      </span>
+    </Button>
+  );
+};
+
 const Index = () => {
   const { formatNumber, formatElapsedTime } = useFormatNumber();
   const [{ y }, scrollTo] = useWindowScroll();
   const searchQuery = useAtomValue(searchQueryAtom);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const { results } = useSearch();
-  const { selectionMode, enterSelectionMode } = useBulkSelection();
   const { height } = useWindowSize();
   const { data: counts, isPending } = useQuery({
     queryFn: () =>
@@ -102,18 +125,7 @@ const Index = () => {
 
                 {/* Actions */}
                 <div className="flex items-center justify-between gap-2">
-                  <Button
-                    className="h-9 px-3"
-                    disabled={selectionMode}
-                    onClick={enterSelectionMode}
-                    size="sm"
-                    variant="outline"
-                  >
-                    <ListChecks className="h-4 w-4 ltr:mr-1.5 rtl:ml-1.5" />
-                    <span className="text-sm">
-                      <Trans>Select</Trans>
-                    </span>
-                  </Button>
+                  <SelectionModeButton className="hidden sm:inline-flex" />
 
                   <Button
                     asChild
@@ -164,7 +176,9 @@ const Index = () => {
             </div>
 
             <div className="px-4 pt-4 pb-4 sm:px-6">
-              <DictionaryFilters />
+              <DictionaryFilters
+                trailingAction={<SelectionModeButton className="sm:hidden" />}
+              />
             </div>
           </Card>
         </motion.div>


### PR DESCRIPTION
## Problem

On the dictionary page below the `sm` breakpoint, the actions row stacks under the heading and has to fit **Select**, **Add word**, and **Review** side by side, leaving the three buttons cramped. The row directly below holds only the **Show filters** toggle, with the rest of that line empty.

## Change

Select moves onto the filters toggle's row on small screens, and stays with the other actions from `sm` up. Desktop layout is unchanged.

## Why this way

- `DictionaryFilters` gained an optional `trailingAction` slot rendered beside the toggle, rather than importing the bulk-selection state itself — the filters component stays unaware of bulk selection, and the slot is reusable if another action ever needs that row.
- The button is a single local `SelectionModeButton` component in the route, rendered twice with complementary visibility classes (`hidden sm:inline-flex` / `sm:hidden`). Two placements, one definition, so they can't drift apart. The hidden copy is `display: none`, so it isn't focusable or announced.

## Testing

`tsc --noEmit` on `apps/web` is clean. Layout change only — no behavior or state changes, and no new translatable strings (the `Select` label already existed). Not yet checked in a browser at both breakpoints; worth a quick look during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01724PZEj54g7kFgT16U4hJz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a selection mode action to the search interface on desktop and smaller screens.
  * The action is displayed alongside dictionary filters on mobile layouts for easier access.
* **Improvements**
  * Updated the dictionary filter area to support additional actions without changing existing filter behavior.
  * Improved consistency of action placement across responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->