### PR TITLE
fix(api): mint full-access db tokens without the SDK

### DIFF
--- a/apps/api/scripts/apply-user-db-migrations.ts
+++ b/apps/api/scripts/apply-user-db-migrations.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import {
   applyAllNewMigrations,
-  tursoPlatformClient,
+  createUserAccessToken,
 } from "../src/clients/turso";
 import { db } from "../src/db";
 import { users } from "../src/db/schema/auth";
@@ -17,10 +17,7 @@ const refreshAccessToken = async (
 ): Promise<string> => {
   logger.info({ dbName, dbId }, "Access token expired, creating new token...");
 
-  const newToken = await tursoPlatformClient.databases.createToken(dbName, {
-    authorization: "full-access",
-    expiration: "2w",
-  });
+  const newToken = await createUserAccessToken({ dbName });
 
   // Update the token in the databases table
   await db

--- a/apps/api/src/clients/turso.ts
+++ b/apps/api/src/clients/turso.ts
@@ -35,11 +35,16 @@ const TOKEN_AUTHORIZATION_CLAIM = {
  *
  * The SDK always sends a `permissions.read_attach` body, even when the caller
  * asks for no permissions (its `createToken` defaults the database list to
- * `[]`). A token minted with that body comes back carrying a `p` (permissions)
- * claim and no `a` claim at all -- so `authorization=read-only` is silently
- * dropped and the token can write. Sending no body, as the platform API docs
- * do, yields `a: "ro"` and a token the database rejects writes on with
- * "SQL write operations are forbidden".
+ * `[]`). That body breaks token minting two separate ways:
+ *
+ * - A token minted with it comes back carrying a `p` (permissions) claim and no
+ *   `a` claim at all -- so `authorization=read-only` is silently dropped and the
+ *   token can write.
+ * - Turso's AWS-hosted platform rejects the body outright with "attach is not
+ *   supported at AWS", so the call throws and no token is minted at all.
+ *
+ * Sending no body, as the platform API docs do, avoids both: the response
+ * carries the `a` claim matching the requested authorization.
  */
 const mintDatabaseToken = async ({
   dbName,
@@ -103,8 +108,8 @@ const mintDatabaseToken = async ({
  * stored, so they're kept shorter-lived -- but still comfortably longer than
  * the CLI's 24h cache refresh buffer, or every command would re-fetch one.
  *
- * Read-only tokens bypass `@tursodatabase/api`, which cannot mint one -- see
- * {@link mintDatabaseToken}.
+ * Every token bypasses `@tursodatabase/api`, which can no longer mint one at
+ * all -- see {@link mintDatabaseToken}.
  */
 export const createUserAccessToken = async ({
   dbName,
@@ -114,18 +119,8 @@ export const createUserAccessToken = async ({
   dbName: string;
   authorization?: TokenAuthorization;
   expiration?: string;
-}): Promise<{ jwt: string }> => {
-  if (authorization === "read-only") {
-    return mintDatabaseToken({ dbName, authorization, expiration });
-  }
-
-  const accessToken = await tursoPlatformClient.databases.createToken(dbName, {
-    authorization,
-    expiration,
-  });
-
-  return accessToken;
-};
+}): Promise<{ jwt: string }> =>
+  mintDatabaseToken({ dbName, authorization, expiration });
 
 /** See {@link createUserAccessToken}. */
 export const READ_ONLY_TOKEN_EXPIRATION = "7d";
@@ -313,10 +308,7 @@ const refreshAccessToken = async (
     "Refreshing access token..."
   );
 
-  const newToken = await tursoPlatformClient.databases.createToken(dbName, {
-    authorization: "full-access",
-    expiration: "2w",
-  });
+  const newToken = await createUserAccessToken({ dbName });
 
   await centralDb
     .update(databases)

--- a/apps/api/src/utils/migration-utils.ts
+++ b/apps/api/src/utils/migration-utils.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@libsql/client";
 import { eq } from "drizzle-orm";
-import { tursoPlatformClient } from "../clients/turso";
+import { createUserAccessToken } from "../clients/turso";
 import { db } from "../db";
 import { databases } from "../db/schema/databases";
 import { logger } from "./logger";
@@ -11,10 +11,7 @@ export const refreshAccessToken = async (
 ): Promise<string> => {
   logger.info({ dbName, dbId }, "Access token expired, creating new token...");
 
-  const newToken = await tursoPlatformClient.databases.createToken(dbName, {
-    authorization: "full-access",
-    expiration: "2w",
-  });
+  const newToken = await createUserAccessToken({ dbName });
 
   await db
     .update(databases)


### PR DESCRIPTION
## Problem

Users are locked out of the app once their stored database token expires. `GET /databases/user` throws:

```
TursoClientError: attach is not supported at AWS
```

The web client turns that into `get_db_info_failed`, and `_authorized-layout` (`apps/web/src/routes/_authorized-layout/route.tsx:373`) throws a `DisplayError` rather than loading. The session is valid — the app just never renders, so users report it as a broken login.

Live in production now: one user has been hard-blocked since 14:50 UTC today, retrying across three sessions, still failing.

## Cause

`@tursodatabase/api`'s `createToken` unconditionally sends a `permissions.read_attach` body, even when the caller asks for no permissions. Turso's AWS-hosted platform now rejects any request carrying that field. The call throws — no token is minted at all.

Nothing on this path had changed in ~10 months (`turso.ts` last touched here 2025-10-08). The running API process has been up since Jul 29 and spans the onset, so no deploy is involved. The trigger was a server-side change at Turso.

## Change

`mintDatabaseToken` (`turso.ts:44`) already bypasses the SDK with a direct platform API call and no body. It was added in 5fe2fcd for a different reason — that same body made `authorization=read-only` come back with a `p` claim and no `a` claim, silently minting a writable token — and was gated to read-only only. Full access stayed on the SDK, and that's the path that broke.

This removes the gate so all authorizations go through the direct call, and points the three remaining SDK call sites at `createUserAccessToken`:

| Site | Purpose |
|---|---|
| `src/clients/turso.ts:307` | `refreshAccessToken` — the failing path |
| `src/utils/migration-utils.ts:8` | `refreshAccessToken` (duplicate impl) |
| `scripts/apply-user-db-migrations.ts:14` | ops script, same shape |

Turso's [docs](https://docs.turso.tech/api-reference/databases/create-token) confirm the shape: `authorization` is a query param (`full-access` | `read-only`), and the canonical example sends it with no body.

## Why it matters beyond one user

Blast radius grows on its own. Stored tokens are 2w-lived, so each one hits this as it expires — a rolling lockout with no deploy needed to trigger it. New signups fail immediately, since `createNewUserDb` mints full-access on the spot.

Recovery needs no intervention: once deployed, the next `GET /databases/user` refreshes successfully and persists the new token.

## Reviewer note — verify before deploying

`mintDatabaseToken` asserts the returned JWT's `a` claim matches the requested authorization (`turso.ts:85`), which is `rw` for full access. **That assertion is only empirically known to hold for `ro`.** The docs don't state the claim value.

If Turso returns something else for full access, the guard throws and the outage persists with a clearer message — it fails closed rather than handing out a wrong-privilege token, but it doesn't fix anything. Worth minting one against the real platform API first. I couldn't verify this without platform credentials.

## Follow-up (not in this PR)

`refreshAccessToken` is duplicated three times with near-identical bodies. Worth collapsing, but kept out to keep this diff minimal for an urgent fix.

## Testing

- `tsc --noEmit` clean
- `bun test` — 9/9 pass
- biome clean
- Not exercised against the live Turso API — see the reviewer note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)